### PR TITLE
Updated yara-x to version v0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22
 toolchain go1.23.1
 
 require (
-	github.com/VirusTotal/yara-x/go v0.8.0
+	github.com/VirusTotal/yara-x/go v0.9.0
 	github.com/djherbis/times v1.6.0
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.23

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/VirusTotal/yara-x/go v0.8.0 h1:OPtCIusgL5mi7zc7MHcEhi0GoFz8t6pLXv432Pt0OpY=
-github.com/VirusTotal/yara-x/go v0.8.0/go.mod h1:lgXP/nkYX349MVowrtTtU5hzMdCOWQLv3+wKll9+0F8=
+github.com/VirusTotal/yara-x/go v0.9.0 h1:pyluOxlO0KilCPWBXtOtT17WIyEGH/ChVuRpYSC2DH4=
+github.com/VirusTotal/yara-x/go v0.9.0/go.mod h1:lgXP/nkYX349MVowrtTtU5hzMdCOWQLv3+wKll9+0F8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/vendor/github.com/VirusTotal/yara-x/go/main.go
+++ b/vendor/github.com/VirusTotal/yara-x/go/main.go
@@ -5,29 +5,80 @@ package yara_x
 // #cgo static_link pkg-config: --static yara_x_capi
 // #include <yara_x.h>
 //
-// uint64_t meta_i64(void* value) {
+// static inline uint64_t meta_i64(void* value) {
 //   return ((YRX_METADATA_VALUE*) value)->i64;
 // }
 //
-// double meta_f64(void* value) {
+// static inline double meta_f64(void* value) {
 //   return ((YRX_METADATA_VALUE*) value)->f64;
 // }
 //
-// bool meta_bool(void* value) {
+// static inline bool meta_bool(void* value) {
 //   return ((YRX_METADATA_VALUE*) value)->boolean;
 // }
 //
-// char* meta_str(void* value) {
+// static inline const char* meta_str(void* value) {
 //   return ((YRX_METADATA_VALUE*) value)->string;
 // }
 //
-// YRX_METADATA_BYTES* meta_bytes(void* value) {
+// static inline YRX_METADATA_BYTES* meta_bytes(void* value) {
 //   return &(((YRX_METADATA_VALUE*) value)->bytes);
 // }
+//
+// enum YRX_RESULT static inline _yrx_rules_iter(
+//		const struct YRX_RULES *rules,
+//		YRX_RULE_CALLBACK callback,
+//		uintptr_t rules_handle)
+// {
+//   return yrx_rules_iter(rules, callback, (void*) rules_handle);
+// }
+//
+// enum YRX_RESULT static inline _yrx_rules_iter_imports(
+//		const struct YRX_RULES *rules,
+//		YRX_IMPORT_CALLBACK callback,
+//		uintptr_t imports_handle)
+// {
+//   return yrx_rules_iter_imports(rules, callback, (void*) imports_handle);
+// }
+//
+// enum YRX_RESULT static inline _yrx_rule_iter_metadata(
+//		const struct YRX_RULE *rule,
+//		YRX_METADATA_CALLBACK callback,
+//		uintptr_t metadata_handle)
+// {
+//   return yrx_rule_iter_metadata(rule, callback, (void*) metadata_handle);
+// }
+//
+// enum YRX_RESULT static inline _yrx_rule_iter_patterns(
+//		const struct YRX_RULE *rule,
+//		YRX_PATTERN_CALLBACK callback,
+//		uintptr_t patterns_handle)
+// {
+//   return yrx_rule_iter_patterns(rule, callback, (void*) patterns_handle);
+// }
+//
+// enum YRX_RESULT static inline _yrx_pattern_iter_matches(
+//		const struct YRX_PATTERN *pattern,
+//		YRX_MATCH_CALLBACK callback,
+//		uintptr_t matches_handle)
+// {
+//   return yrx_pattern_iter_matches(pattern, callback, (void*) matches_handle);
+// }
+//
+// extern void ruleCallback(YRX_RULE*, uintptr_t);
+// extern void importCallback(char*, uintptr_t);
+// extern void metadataCallback(YRX_METADATA*, uintptr_t);
+// extern void patternCallback(YRX_PATTERN*, uintptr_t);
+// extern void matchCallback(YRX_MATCH*, uintptr_t);
+//
 import "C"
+
 import (
 	"errors"
+	"io"
+	"reflect"
 	"runtime"
+	"runtime/cgo"
 	"unsafe"
 )
 
@@ -44,25 +95,30 @@ func Compile(src string, opts ...CompileOption) (*Rules, error) {
 	return c.Build(), nil
 }
 
-// Deserialize deserializes rules from a byte slice.
+// ReadFrom reads compiled rules from a reader.
 //
-// The counterpart is [Rules.Serialize]
-func Deserialize(data []byte) (*Rules, error) {
+// The counterpart is [Rules.WriteTo].
+func ReadFrom(r io.Reader) (*Rules, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
 	var ptr *C.uint8_t
 	if len(data) > 0 {
 		ptr = (*C.uint8_t)(unsafe.Pointer(&(data[0])))
 	}
 
-	r := &Rules{cRules: nil}
+	rules := &Rules{cRules: nil}
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	if C.yrx_rules_deserialize(ptr, C.size_t(len(data)), &r.cRules) != C.SUCCESS {
+	if C.yrx_rules_deserialize(ptr, C.size_t(len(data)), &rules.cRules) != C.SUCCESS {
 		return nil, errors.New(C.GoString(C.yrx_last_error()))
 	}
 
-	return r, nil
+	return rules, nil
 }
 
 // Rules represents a set of compiled YARA rules.
@@ -71,20 +127,64 @@ type Rules struct{ cRules *C.YRX_RULES }
 // Scan some data with the compiled rules.
 func (r *Rules) Scan(data []byte) (*ScanResults, error) {
 	scanner := NewScanner(r)
+	defer scanner.Destroy()
 	return scanner.Scan(data)
 }
 
-// Serialize converts the compiled rules into a byte slice.
-func (r *Rules) Serialize() ([]byte, error) {
+// WriteTo writes the compiled rules into a writer.
+//
+// The counterpart is [ReadFrom].
+func (r *Rules) WriteTo(w io.Writer) (int64, error) {
 	var buf *C.YRX_BUFFER
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	if C.yrx_rules_serialize(r.cRules, &buf) != C.SUCCESS {
-		return nil, errors.New(C.GoString(C.yrx_last_error()))
+		return 0, errors.New(C.GoString(C.yrx_last_error()))
 	}
 	defer C.yrx_buffer_destroy(buf)
 	runtime.KeepAlive(r)
-	return C.GoBytes(unsafe.Pointer(buf.data), C.int(buf.length)), nil
+
+	// We are going to write into `w` in chunks of 64MB.
+	const chunkSize = 1 << 26
+
+	// This is the slice that contains the next chunk that will be written.
+	var chunk []byte
+
+	// Modify the `chunk` slice, making it point to the buffer returned
+	// by yrx_rules_serialize. This allows us to access the buffer from
+	// Go without copying the data. This is safe because the slice won't
+	// be used after the buffer is destroyed.
+	chunkHdr := (*reflect.SliceHeader)(unsafe.Pointer(&chunk))
+	chunkHdr.Data = uintptr(unsafe.Pointer(buf.data))
+	chunkHdr.Len = chunkSize
+	chunkHdr.Cap = chunkSize
+
+	bufLen := C.ulong(buf.length)
+	bytesWritten := int64(0)
+
+	for {
+		// If the data to be written is shorted than `chunkSize`, set the length
+		// of the `chunk` slice to this length.
+		if bufLen < chunkSize {
+			chunkHdr.Len = int(bufLen)
+			chunkHdr.Cap = int(bufLen)
+		}
+		if n, err := w.Write(chunk); err == nil {
+			bytesWritten += int64(n)
+		} else {
+			return 0, err
+		}
+		// If `bufLen` is still greater than `chunkSize`, there's more data to
+		// write, if not, we are done.
+		if bufLen > chunkSize {
+			chunkHdr.Data += chunkSize
+			bufLen -= chunkSize
+		} else {
+			break
+		}
+	}
+
+	return bytesWritten, nil
 }
 
 // Destroy destroys the compiled YARA rules represented by [Rules].
@@ -99,14 +199,83 @@ func (r *Rules) Destroy() {
 	runtime.SetFinalizer(r, nil)
 }
 
+// This is the callback called by yrx_rules_iterate, when Rules.GetRules is
+// called.
+//export onRule
+func onRule(rule *C.YRX_RULE, handle C.uintptr_t) {
+	h := cgo.Handle(handle)
+	rules, ok := h.Value().(*[]*Rule)
+	if !ok {
+		panic("onRule didn't receive a *[]Rule")
+	}
+	*rules = append(*rules, newRule(rule))
+}
+
+// Slice returns a slice with all the individual rules contained in this
+// set of compiled rules.
+func (r *Rules) Slice() []*Rule {
+	rules := make([]*Rule, 0)
+	handle := cgo.NewHandle(&rules)
+	defer handle.Delete()
+
+	C._yrx_rules_iter(
+		r.cRules,
+		C.YRX_RULE_CALLBACK(C.ruleCallback),
+		C.uintptr_t(handle))
+
+	runtime.KeepAlive(r)
+	return rules
+}
+
+// Count returns the total number of rules.
+//
+// This is more a more efficient alternative to len(rules.Slice()).
+func (r *Rules) Count() int {
+	count := C.yrx_rules_count(r.cRules)
+	runtime.KeepAlive(r)
+	return int(count)
+}
+
+// Imports returns the names of the imported modules.
+func (r *Rules) Imports() []string {
+	imports := make([]string, 0)
+	handle := cgo.NewHandle(&imports)
+	defer handle.Delete()
+
+	C._yrx_rules_iter_imports(
+		r.cRules,
+		C.YRX_RULE_CALLBACK(C.importCallback),
+		C.uintptr_t(handle))
+
+	runtime.KeepAlive(r)
+	return imports
+}
+
 // Rule represents a YARA rule.
 type Rule struct {
 	namespace  string
 	identifier string
-	cPatterns  *C.YRX_PATTERNS
 	patterns   []Pattern
-	cMetadata  *C.YRX_METADATA
 	metadata   []Metadata
+}
+
+// Pattern represents a pattern in a Rule.
+type Pattern struct {
+	identifier string
+	matches    []Match
+}
+
+// Metadata represents a metadata in a Rule.
+type Metadata struct {
+	identifier string
+	value      interface{}
+}
+
+// Match contains information about the offset where a match occurred and
+// the length of the match.
+type Match struct {
+	offset uint64
+	length uint64
 }
 
 // Creates a new Rule from it's C counterpart.
@@ -126,25 +295,36 @@ func newRule(cRule *C.YRX_RULE) *Rule {
 
 	identifier := C.GoStringN((*C.char)(unsafe.Pointer(str)), C.int(len))
 
+	metadata := make([]Metadata, 0)
+	metadataHandle := cgo.NewHandle(&metadata)
+	defer metadataHandle.Delete()
+
+	if C._yrx_rule_iter_metadata(
+		cRule,
+		C.YRX_PATTERN_CALLBACK(C.metadataCallback),
+		C.uintptr_t(metadataHandle)) != C.SUCCESS {
+		panic("yrx_rule_iter_metadata failed")
+	}
+
+	patterns := make([]Pattern, 0)
+	patternsHandle := cgo.NewHandle(&patterns)
+	defer patternsHandle.Delete()
+
+	if C._yrx_rule_iter_patterns(
+		cRule,
+		C.YRX_PATTERN_CALLBACK(C.patternCallback),
+		C.uintptr_t(patternsHandle)) != C.SUCCESS {
+		panic("yrx_rule_iter_patterns failed")
+	}
+
 	rule := &Rule{
 		namespace,
 		identifier,
-		C.yrx_rule_patterns(cRule),
-		nil,
-		C.yrx_rule_metadata(cRule),
-		nil,
+		patterns,
+		metadata,
 	}
 
-	runtime.SetFinalizer(rule, (*Rule).destroy)
 	return rule
-}
-
-func (r *Rule) destroy() {
-	C.yrx_patterns_destroy(r.cPatterns)
-	if r.cMetadata != nil {
-		C.yrx_metadata_destroy(r.cMetadata)
-	}
-	runtime.SetFinalizer(r, nil)
 }
 
 // Identifier returns the rule's identifier.
@@ -157,86 +337,24 @@ func (r *Rule) Namespace() string {
 	return r.namespace
 }
 
-// Metadata returns the rule's metadata
-func (r *Rule) Metadata() []Metadata {
-	// if this method was called before, return the metadata already cached.
-	if r.metadata != nil {
-		return r.metadata
-	}
-
-	numMetadata := int(r.cMetadata.num_entries)
-	cMetadata := unsafe.Slice(r.cMetadata.entries, numMetadata)
-	r.metadata = make([]Metadata, numMetadata)
-
-	for i, metadata := range cMetadata {
-		r.metadata[i].Identifier = C.GoString(metadata.identifier)
-		switch metadata.value_type {
-		case C.I64:
-			r.metadata[i].Value = int64(
-				C.meta_i64(unsafe.Pointer(&metadata.value)))
-		case C.F64:
-			r.metadata[i].Value = float64(
-				C.meta_f64(unsafe.Pointer(&metadata.value)))
-		case C.BOOLEAN:
-			r.metadata[i].Value = bool(
-				C.meta_bool(unsafe.Pointer(&metadata.value)))
-		case C.STRING:
-			r.metadata[i].Value = C.GoString(
-				C.meta_str(unsafe.Pointer(&metadata.value)))
-		case C.BYTES:
-			bytes := C.meta_bytes(unsafe.Pointer(&metadata.value))
-			r.metadata[i].Value = C.GoBytes(
-				unsafe.Pointer(bytes.data),
-				C.int(bytes.length),
-			)
-		}
-	}
-
-	return r.metadata
+// Identifier associated to the metadata.
+func (m *Metadata) Identifier() string {
+	return m.identifier
 }
 
-// Metadata represents a metadata in a Rule.
-type Metadata struct {
-	Identifier string
-	Value      interface{}
+// Value associated to the metadata.
+func (m *Metadata) Value() interface{} {
+	return m.value
+}
+
+// Metadata returns the rule's metadata
+func (r *Rule) Metadata() []Metadata {
+	return r.metadata
 }
 
 // Patterns returns the patterns defined by this rule.
 func (r *Rule) Patterns() []Pattern {
-	// If this method was called before, return the patterns already cached.
-	if r.patterns != nil {
-		return r.patterns
-	}
-
-	numPatterns := int(r.cPatterns.num_patterns)
-	cPatterns := unsafe.Slice(r.cPatterns.patterns, numPatterns)
-	r.patterns = make([]Pattern, numPatterns)
-
-	for i, pattern := range cPatterns {
-		numMatches := int(pattern.num_matches)
-		cMatches := unsafe.Slice(pattern.matches, numMatches)
-		matches := make([]Match, numMatches)
-
-		for j, match := range cMatches {
-			matches[j] = Match{
-				offset: uint(match.offset),
-				length: uint(match.length),
-			}
-		}
-
-		r.patterns[i] = Pattern{
-			identifier: C.GoString(pattern.identifier),
-			matches:    matches,
-		}
-	}
-
 	return r.patterns
-}
-
-// Pattern represents a pattern in a Rule.
-type Pattern struct {
-	identifier string
-	matches    []Match
 }
 
 // Identifier returns the pattern's identifier (i.e: $a, $foo).
@@ -249,19 +367,122 @@ func (p *Pattern) Matches() []Match {
 	return p.matches
 }
 
-// Match contains information about the offset where a match occurred and
-// the length of the match.
-type Match struct {
-	offset uint
-	length uint
-}
-
 // Offset returns the offset within the scanned data where a match occurred.
-func (m *Match) Offset() uint {
+func (m *Match) Offset() uint64 {
 	return m.offset
 }
 
 // Length returns the length of a match in bytes.
-func (m *Match) Length() uint {
+func (m *Match) Length() uint64 {
 	return m.length
+}
+
+// This is the callback called by yrx_rules_iter, when Rules.GetRules is
+// called.
+//
+//export ruleCallback
+func ruleCallback(rule *C.YRX_RULE, handle C.uintptr_t) {
+	h := cgo.Handle(handle)
+	rules, ok := h.Value().(*[]*Rule)
+	if !ok {
+		panic("ruleCallback didn't receive a *[]Rule")
+	}
+	*rules = append(*rules, newRule(rule))
+}
+
+// This is the callback called by yrx_rules_iter_imports, when Rules.Imports
+// is called.
+//
+//export importCallback
+func importCallback(moduleName *C.char, handle C.uintptr_t) {
+	h := cgo.Handle(handle)
+	imports, ok := h.Value().(*[]string)
+	if !ok {
+		panic("importCallback didn't receive a *[]string")
+	}
+	*imports = append(*imports, C.GoString(moduleName))
+}
+
+// This is the callback called by yrx_rules_iter_patterns
+//
+//export patternCallback
+func patternCallback(pattern *C.YRX_PATTERN, handle C.uintptr_t) {
+	h := cgo.Handle(handle)
+	patterns, ok := h.Value().(*[]Pattern)
+
+	if !ok {
+		panic("patternCallback didn't receive a *[]Pattern")
+	}
+
+	var str *C.uint8_t
+	var len C.size_t
+
+	if C.yrx_pattern_identifier(pattern, &str, &len) != C.SUCCESS {
+		panic("yrx_pattern_identifier failed")
+	}
+
+	matches := make([]Match, 0)
+	matchesHandle := cgo.NewHandle(&matches)
+	defer matchesHandle.Delete()
+
+	if C._yrx_pattern_iter_matches(pattern,
+		C.YRX_MATCH_CALLBACK(C.matchCallback),
+		C.uintptr_t(matchesHandle)) != C.SUCCESS {
+		panic("yrx_pattern_iter_matches failed")
+	}
+
+	*patterns = append(*patterns, Pattern{
+		identifier: C.GoStringN((*C.char)(unsafe.Pointer(str)), C.int(len)),
+		matches:    matches,
+	})
+}
+
+// This is the callback called by yrx_rules_iter_patterns
+//
+//export metadataCallback
+func metadataCallback(metadata *C.YRX_METADATA, handle C.uintptr_t) {
+	h := cgo.Handle(handle)
+	m, ok := h.Value().(*[]Metadata)
+	if !ok {
+		panic("matchCallback didn't receive a *[]Metadata")
+	}
+
+	var value interface{}
+
+	switch metadata.value_type {
+	case C.I64:
+		value = int64(C.meta_i64(unsafe.Pointer(&metadata.value)))
+	case C.F64:
+		value = float64(C.meta_f64(unsafe.Pointer(&metadata.value)))
+	case C.BOOLEAN:
+		value = bool(C.meta_bool(unsafe.Pointer(&metadata.value)))
+	case C.STRING:
+		value = C.GoString(C.meta_str(unsafe.Pointer(&metadata.value)))
+	case C.BYTES:
+		bytes := C.meta_bytes(unsafe.Pointer(&metadata.value))
+		value = C.GoBytes(
+			unsafe.Pointer(bytes.data),
+			C.int(bytes.length),
+		)
+	}
+
+	*m = append(*m, Metadata{
+		identifier: C.GoString(metadata.identifier),
+		value:      value,
+	})
+}
+
+// This is the callback called by yrx_rules_iter_patterns
+//
+//export matchCallback
+func matchCallback(match *C.YRX_MATCH, handle C.uintptr_t) {
+	h := cgo.Handle(handle)
+	matches, ok := h.Value().(*[]Match)
+	if !ok {
+		panic("matchCallback didn't receive a *[]Match")
+	}
+	*matches = append(*matches, Match{
+		offset: uint64(match.offset),
+		length: uint64(match.length),
+	})
 }

--- a/vendor/github.com/VirusTotal/yara-x/go/scanner.go
+++ b/vendor/github.com/VirusTotal/yara-x/go/scanner.go
@@ -1,6 +1,17 @@
 package yara_x
 
+// #include <yara_x.h>
+//
+// enum YRX_RESULT static inline _yrx_scanner_on_matching_rule(
+//     struct YRX_SCANNER *scanner,
+//     YRX_RULE_CALLBACK callback,
+//     uintptr_t user_data) {
+//   return yrx_scanner_on_matching_rule(scanner, callback, (void*) user_data);
+// }
+//
+// void onMatchingRule(YRX_RULE*, uintptr_t);
 import "C"
+
 import (
 	"errors"
 	"fmt"
@@ -15,10 +26,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// #include <yara_x.h>
-// void onMatchingRule(YRX_RULE*, void*);
-import "C"
-
 // Scanner scans data with a set of compiled YARA rules.
 type Scanner struct {
 	// Pointer to C-side scanner.
@@ -28,11 +35,7 @@ type Scanner struct {
 	// is garbage collected the associated C.YRX_RULES object is destroyed
 	// before the C.YRX_SCANNER object.
 	rules *Rules
-	// Handle to the scanner itself that is passed to C callbacks. Notice that
-	// this is not actually the handle but a pointer to the handle, and the
-	// memory that stores the handle is allocated via C.malloc because the
-	// pointer is passed to C code. We don't want the garbage collector messing
-	// with the memory that holds the handle.
+	// Handle to the scanner itself that is passed to C callbacks.
 	//
 	// Go 1.21 introduces https://pkg.go.dev/runtime#Pinner.Pin, which allows
 	// to pin a Go object in memory, guaranteeing that the garbage collector
@@ -40,7 +43,8 @@ type Scanner struct {
 	// struct and pass a pointer to the scanner to the C code, making this
 	// handle unnecessary. At this time (Feb 2024) Go 1.21 is only 6 months
 	// old, and we want to support older versions.
-	handle *cgo.Handle
+	handle cgo.Handle
+
 	// Rules that matched during the last scan.
 	matchingRules []*Rule
 }
@@ -55,6 +59,18 @@ func (s ScanResults) MatchingRules() []*Rule {
 	return s.matchingRules
 }
 
+// This is the callback function called every time a YARA rule matches.
+//
+//export onMatchingRule
+func onMatchingRule(rule *C.YRX_RULE, handle C.uintptr_t) {
+	h := cgo.Handle(handle)
+	scanner, ok := h.Value().(*Scanner)
+	if !ok {
+		panic("onMatchingRule didn't receive a Scanner")
+	}
+	scanner.matchingRules = append(scanner.matchingRules, newRule(rule))
+}
+
 // NewScanner creates a Scanner that will use the provided YARA rules.
 //
 // It's safe to pass the same Rules to multiple scanners, and use each scanner
@@ -66,19 +82,12 @@ func NewScanner(r *Rules) *Scanner {
 		panic("yrx_scanner_create failed")
 	}
 
-	// Allocate the memory that will hold the handle. This memory is allocated
-	// using C.malloc because a pointer to it is passed to C code, and we don't
-	// want the garbage collector messing with it.
-	s.handle = (*cgo.Handle)(C.malloc(C.size_t(unsafe.Sizeof(s.handle))))
+	s.handle = cgo.NewHandle(s)
 
-	// Create a new handle that points to the scanner, and store it in the
-	// newly allocated memory.
-	*s.handle = cgo.NewHandle(s)
-
-	C.yrx_scanner_on_matching_rule(
+	C._yrx_scanner_on_matching_rule(
 		s.cScanner,
-		C.YRX_ON_MATCHING_RULE(C.onMatchingRule),
-		unsafe.Pointer(s.handle))
+		C.YRX_RULE_CALLBACK(C.onMatchingRule),
+		C.uintptr_t(s.handle))
 
 	runtime.SetFinalizer(s, (*Scanner).Destroy)
 	return s
@@ -236,20 +245,8 @@ func (s *Scanner) Destroy() {
 	if s.cScanner != nil {
 		C.yrx_scanner_destroy(s.cScanner)
 		s.handle.Delete()
-		C.free(unsafe.Pointer(s.handle))
 		s.cScanner = nil
 	}
+	s.rules = nil
 	runtime.SetFinalizer(s, nil)
-}
-
-// This is the callback function called every time a YARA rule matches.
-//
-//export onMatchingRule
-func onMatchingRule(rule *C.YRX_RULE, handlePtr unsafe.Pointer) {
-	handle := *(*cgo.Handle)(handlePtr)
-	scanner, ok := handle.Value().(*Scanner)
-	if !ok {
-		panic("onMatchingRule didn't receive a Scanner")
-	}
-	scanner.matchingRules = append(scanner.matchingRules, newRule(rule))
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/VirusTotal/yara-x/go v0.8.0
+# github.com/VirusTotal/yara-x/go v0.9.0
 ## explicit; go 1.18
 github.com/VirusTotal/yara-x/go
 # github.com/djherbis/times v1.6.0


### PR DESCRIPTION
This PR changes yara-x from v0.8.0 to v0.9.0

Be sure to update the Rust yara-x library to this specific version (git checkout tags/v0.9.0) and rebuild it locally.
As there are no prebuilds with yara support yet, no new release is created.

**Tests passed:**

task: [test] go test -v
=== RUN   TestCreateFileTroveDB
=== RUN   TestCreateFileTroveDB/Create_database
--- PASS: TestCreateFileTroveDB (0.01s)
    --- PASS: TestCreateFileTroveDB/Create_database (0.01s)
=== RUN   TestReadDC
=== RUN   TestReadDC/Title
--- PASS: TestReadDC (0.00s)
    --- PASS: TestReadDC/Title (0.00s)
=== RUN   TestEntropy
=== RUN   TestEntropy/entropy
=== RUN   TestEntropy/entropy#01
--- PASS: TestEntropy (0.00s)
    --- PASS: TestEntropy/entropy (0.00s)
    --- PASS: TestEntropy/entropy#01 (0.00s)
=== RUN   TestExifDecode
=== RUN   TestExifDecode/EXIF_screenshot_1.jpg
--- PASS: TestExifDecode (0.00s)
    --- PASS: TestExifDecode/EXIF_screenshot_1.jpg (0.00s)
=== RUN   TestCreateFileList
=== RUN   TestCreateFileList/testdata_file_list
--- PASS: TestCreateFileList (0.00s)
    --- PASS: TestCreateFileList/testdata_file_list (0.00s)
=== RUN   TestHashit
=== RUN   TestHashit/md5
=== RUN   TestHashit/sha1
=== RUN   TestHashit/sha256
--- PASS: TestHashit (0.00s)
    --- PASS: TestHashit/md5 (0.00s)
    --- PASS: TestHashit/sha1 (0.00s)
    --- PASS: TestHashit/sha256 (0.00s)
=== RUN   TestSiegfriedIdent
=== RUN   TestSiegfriedIdent/Test_file_1
--- PASS: TestSiegfriedIdent (0.04s)
    --- PASS: TestSiegfriedIdent/Test_file_1 (0.02s)
=== RUN   TestGetFileTimes
=== RUN   TestGetFileTimes/File_Time_white.jpg
--- PASS: TestGetFileTimes (0.00s)
    --- PASS: TestGetFileTimes/File_Time_white.jpg (0.00s)
=== RUN   TestCreateUUID
=== RUN   TestCreateUUID/UUID_length
--- PASS: TestCreateUUID (0.00s)
    --- PASS: TestCreateUUID/UUID_length (0.00s)
=== RUN   TestYaraCompile
=== RUN   TestYaraCompile/Successful_compile
--- PASS: TestYaraCompile (0.01s)
    --- PASS: TestYaraCompile/Successful_compile (0.01s)
=== RUN   TestYaraScan
=== RUN   TestYaraScan/Yara_Matching_Test_Rule
--- PASS: TestYaraScan (0.00s)
    --- PASS: TestYaraScan/Yara_Matching_Test_Rule (0.00s)
=== RUN   FuzzCreateFileTroveDB
--- PASS: FuzzCreateFileTroveDB (0.00s)
PASS
ok  	github.com/steffenfritz/FileTrove	0.643s