### PR TITLE
Improve First Dev Experience

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
 
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Task
-        uses: go-task/setup-task@0ab1b2a65bc55236a3bc64cde78f80e20e8885c2 # v1
+        uses: go-task/setup-task@70f2430ad412f838533de8c0515c749ffb2b8bd3 # v1.1.0
         with:
           version: "3.x"
 
@@ -33,7 +33,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache Rust build
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/.cargo/bin
@@ -52,7 +52,7 @@ jobs:
           go-version: '1.26.1'
 
       - name: Cache Go modules
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
 
@@ -28,7 +28,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache Rust build
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/.cargo/bin
@@ -47,12 +47,12 @@ jobs:
           go-version: '1.26.1'
 
       - name: Install Task
-        uses: go-task/setup-task@0ab1b2a65bc55236a3bc64cde78f80e20e8885c2 # v1
+        uses: go-task/setup-task@70f2430ad412f838533de8c0515c749ffb2b8bd3 # v1.1.0
         with:
           version: "3.x"
 
       - name: Cache Go modules
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~\AppData\Local\go-build

--- a/.github/workflows/buildstatus.yml
+++ b/.github/workflows/buildstatus.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
 
@@ -48,7 +48,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Rust
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/.cargo/bin
@@ -73,7 +73,7 @@ jobs:
           cache: true
 
       - name: Install Task
-        uses: go-task/setup-task@0ab1b2a65bc55236a3bc64cde78f80e20e8885c2 # v1
+        uses: go-task/setup-task@70f2430ad412f838533de8c0515c749ffb2b8bd3 # v1.1.0
         with:
           version: "3.x"
 

--- a/.github/workflows/buildstatus.yml
+++ b/.github/workflows/buildstatus.yml
@@ -88,8 +88,9 @@ jobs:
           PC_FILE=$(find $HOME/yara_install -name yara_x_capi.pc | head -1)
           PC_DIR=$(dirname "$PC_FILE")
           LIB_DIR=$(find $HOME/yara_install -name "libyara_x_capi*" -exec dirname {} \; | head -1)
+          PREFIX=$(PKG_CONFIG_PATH=$PC_DIR pkg-config --variable=prefix yara_x_capi)
           echo "PKG_CONFIG_PATH=$PC_DIR" >> $GITHUB_ENV
-          echo "CGO_CFLAGS=-I$(dirname "$LIB_DIR")/include" >> $GITHUB_ENV
+          echo "CGO_CFLAGS=-I$HOME/yara_install$PREFIX/include" >> $GITHUB_ENV
           echo "CGO_LDFLAGS=-L$LIB_DIR" >> $GITHUB_ENV
           echo "CGO_ENABLED=1" >> $GITHUB_ENV
 

--- a/.github/workflows/buildstatus.yml
+++ b/.github/workflows/buildstatus.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     permissions:
@@ -58,8 +58,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Install cargo-c (Linux)
-        if: runner.os == 'Linux'
+      - name: Install cargo-c (Linux/macOS)
+        if: runner.os != 'Windows'
         run: command -v cargo-cinstall >/dev/null 2>&1 || cargo install cargo-c
 
       - name: Install cargo-c (Windows)
@@ -80,16 +80,16 @@ jobs:
       - name: Clone YARA-X
         run: git clone --depth 1 --branch v1.14.0 https://github.com/VirusTotal/yara-x.git
 
-      - name: Build YARA-X C API (Linux)
-        if: runner.os == 'Linux'
+      - name: Build YARA-X C API (Linux/macOS)
+        if: runner.os != 'Windows'
         run: |
           cd yara-x
           cargo cinstall -p yara-x-capi --release --destdir=$HOME/yara_install
-          PC_FILE=$(find $HOME/yara_install -name yara_x_capi.pc)
+          PC_FILE=$(find $HOME/yara_install -name yara_x_capi.pc | head -1)
           PC_DIR=$(dirname "$PC_FILE")
-          LIB_DIR=$(find $HOME/yara_install -name "libyara_x_capi.a" -exec dirname {} \; | head -1)
+          LIB_DIR=$(find $HOME/yara_install -name "libyara_x_capi*" -exec dirname {} \; | head -1)
           echo "PKG_CONFIG_PATH=$PC_DIR" >> $GITHUB_ENV
-          echo "CGO_CFLAGS=-I$HOME/yara_install/usr/local/include" >> $GITHUB_ENV
+          echo "CGO_CFLAGS=-I$(dirname "$LIB_DIR")/include" >> $GITHUB_ENV
           echo "CGO_LDFLAGS=-L$LIB_DIR" >> $GITHUB_ENV
           echo "CGO_ENABLED=1" >> $GITHUB_ENV
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -96,6 +96,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
 
@@ -74,6 +74,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+        uses: github/codeql-action/upload-sarif@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           sarif_file: results.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,6 @@ dist/
 
 # Taskfile state
 .task/
+cmd/ftrove/.yara_env
 testdata/noaccess.rtf
 resources

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,92 @@
+# Building FileTrove from Source
+
+FileTrove requires CGO because it links against the [YARA-X](https://virustotal.github.io/yara-x/) C library. This guide walks you through setting up a complete development environment on **macOS** and **Debian/Ubuntu**.
+
+---
+
+## macOS
+
+### 1. Install Homebrew
+
+If you don't have Homebrew yet:
+
+```sh
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+### 2. Install the Task build tool
+
+```sh
+brew install go-task/tap/go-task
+```
+
+### 3. Install remaining dependencies and build YARA-X
+
+From the repository root, run:
+
+```sh
+cd cmd/ftrove
+task setup_mac
+```
+
+This will:
+- Install Go, Rust, Zig, SQLite, and pkg-config via Homebrew
+- Install `cargo-c`
+- Clone YARA-X v1.14.0 into `$HOME/yara-x` and build its C library into `$HOME/yara_install`
+- Write the required CGO environment variables to `cmd/ftrove/.yara_env` (auto-loaded by subsequent `task` invocations)
+
+### 4. Build
+
+```sh
+task build
+```
+
+---
+
+## Debian / Ubuntu (latest stable or LTS)
+
+### 1. Install the Task build tool
+
+```sh
+curl -fsSL https://taskfile.dev/install.sh | sh -s -- -b ~/.local/bin
+```
+
+Ensure `~/.local/bin` is on your `PATH`, then verify with `task --version`.
+
+### 2. Install remaining dependencies and build YARA-X
+
+From the repository root, run:
+
+```sh
+cd cmd/ftrove
+task setup_linux
+```
+
+This will:
+- Install build tools, pkg-config, sqlite3, and Go via apt (Go 1.21+ supports `GOTOOLCHAIN=auto`, so the version in `go.mod` is fetched automatically)
+- Install Rust via rustup and `cargo-c`
+- Clone YARA-X v1.14.0 into `$HOME/yara-x` and build its C library into `$HOME/yara_install`
+- Write the required CGO environment variables to `cmd/ftrove/.yara_env` (auto-loaded by subsequent `task` invocations)
+
+### 3. Build
+
+```sh
+task build
+```
+
+---
+
+## Running tests
+
+From the repository root:
+
+```sh
+go test -v ./...
+```
+
+For a full integration test (build + install + scan + DB inspection):
+
+```sh
+cd cmd/ftrove
+task changetest
+```

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 <img src="https://github.com/steffenfritz/FileTrove/assets/16431534/b8c1456d-08bb-48bb-afcf-5e99db8466b9" width="300">
 </p>
 
-
-
 ![Build Status](https://github.com/steffenfritz/FileTrove/actions/workflows/buildstatus.yml/badge.svg)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![Go Reference](https://pkg.go.dev/badge/github.com/steffenfritz/FileTrove.svg)](https://pkg.go.dev/github.com/steffenfritz/FileTrove)
@@ -13,12 +11,11 @@
 
 VERSION: v1.0.0-BETA-4
 
-
 ## About
 
 FileTrove indexes files and creates metadata from them.
 
-The application walks a directory tree and identifies all regular files by type with [siegfried](https://github.com/richardlehane/siegfried), giving you the 
+The application walks a directory tree and identifies all regular files by type with [siegfried](https://github.com/richardlehane/siegfried), giving you the
 
 * MIME type
 * [PRONOM](https://www.nationalarchives.gov.uk/PRONOM/) identifier
@@ -43,29 +40,27 @@ Furthermore it creates and calculates
 * hash sums (md5, sha1, sha256, sha512 and blake2b-512)
 * the entropy of each file (up to 1GB)
 
-* and it extracts some EXIF metadata and 
+* and it extracts some EXIF metadata and
 * you can add your own [DublinCore Elements](https://www.dublincore.org/specifications/dublin-core/usageguide/elements/) metadata to scans.
 
 * A very powerful feature is FileTrove's ability to consume [YARA-X](https://virustotal.github.io/yara-x/) rule files.
 
 * FileTrove also checks if the file is in the [NSRL](https://www.nist.gov/itl/ssd/software-quality-group/national-software-reference-library-nsrl).
 
-For this check a 4.0GB BoltDB is needed and can be downloaded with FileTrove during the installation. 
+For this check a 4.0GB BoltDB is needed and can be downloaded with FileTrove during the installation.
 
 You can also create your own database for the NSRL check. You just need a text file with SHA1 hashes, one per line and the tool `admftrove` which is built along with `ftrove`. With this tool you can also add your own hashes to an existing database.
 
-
 All results are written into a SQLite database and can be exported to TSV files.
-
 
 ## How to install
 1. Download a release from https://github.com/steffenfritz/FileTrove/releases or compile from source (using `task build` in the repository root).
    - This will generate both a standard dynamic binary (`ftrove`) and a standalone static binary (e.g., `ftrove_amd64_linux_static`).
 2. Copy the binary you wish to use where you want to install ftrove (the downloaded file has a suffix, omitted in the following documentation)
 3. Run `./ftrove --install .` (Mind the period)
-   
+
 	a) If you don't have already a NSRL database, you have to download it. Please be patient.
-    
+
 	b) If you have a NSRL database copy/move it to the "db" directory that ftrove just created.
 
 4. You are ready to go!
@@ -76,23 +71,16 @@ It is now automatically built and installed during the `task build` process if i
 
 A YARA example rule file can be found in the testdata/yara directory in this repository.
 
-If a rule matches on a file the rule name, the session UUID and the file UUID is written into the table *yara*.
+If a rule matches on a file the rule name, the session UUID and the file UUID is written into the table _yara_.
 
 The YARA rule file itself is not stored in FileTrove's database.
 
-
 ### To compile FileTrove with YARA-X support
 
-1. Install Golang: https://go.dev/doc/install
-2. Install Task build tool: https://taskfile.dev
-3. Clone the repository: `git clone https://github.com/steffenfritz/FileTrove.git`
-4. Change into the directory: `cd FileTrove`
-5. Start build: `task build`
-
-Note: `task build` will automatically attempt to install the YARA-X C library if it's not found on your system (requires `cargo` and `sudo`).
-
+See [BUILDING.md](BUILDING.md) for step-by-step setup instructions on macOS and Debian/Ubuntu.
 
 ## How to run
+
 `./ftrove -h` gives you all flags ftrove understands.
 
 A run only with necessary flags looks like this:
@@ -102,18 +90,19 @@ A run only with necessary flags looks like this:
 where $DIRECTORY is a directory you want to use as a starting point. FileTrove will walk this directory recursively down.
 
 ## How to see the results
-You can export the results via `./ftrove -t $UUID` where $UUID is the session id. 
-Every indexing run gets its own session id. You get a list of all sessions using `./ftrove -l`. 
+
+You can export the results via `./ftrove -t $UUID` where $UUID is the session id.
+Every indexing run gets its own session id. You get a list of all sessions using `./ftrove -l`.
 
 Example:
 
 1. `./ftrove -l`
 2. `./ftrove -t 926be141-ab75-4106-8236-34edfcf102f2`
 
-This will create several TSV files that can be read with Excel, Numbers and your preferred text editor. 
+This will create several TSV files that can be read with Excel, Numbers and your preferred text editor.
 
-
-You can also work with SQL on the database, using sqlite on the console or a GUI like sqlitebrowser (https://sqlitebrowser.org/). Sqliteviz is also a neat tool to visualize the data (https://sqliteviz.com/app/#/).
+You can also work with SQL on the database, using sqlite on the console or a GUI like sqlitebrowser (<https://sqlitebrowser.org/>). Sqliteviz is also a neat tool to visualize the data (<https://sqliteviz.com/app/#/>).
 
 ## Background
+
 FileTrove is the successor of [filedriller](https://github.com/steffenfritz/filedriller) and based on my iPres 2021 paper [Marrying siegfried and the National Software Reference Library](https://phaidra.univie.ac.at/detail/o:1424904)

--- a/README.md
+++ b/README.md
@@ -2,107 +2,82 @@
 <img src="https://github.com/steffenfritz/FileTrove/assets/16431534/b8c1456d-08bb-48bb-afcf-5e99db8466b9" width="300">
 </p>
 
-![Build Status](https://github.com/steffenfritz/FileTrove/actions/workflows/buildstatus.yml/badge.svg)
-[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
-[![Go Reference](https://pkg.go.dev/badge/github.com/steffenfritz/FileTrove.svg)](https://pkg.go.dev/github.com/steffenfritz/FileTrove)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/steffenfritz/FileTrove/badge)](https://scorecard.dev/viewer/?uri=github.com/steffenfritz/FileTrove)
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8952/badge)](https://www.bestpractices.dev/projects/8952)
+<p align="center">
+  <img alt="Build Status" src="https://github.com/steffenfritz/FileTrove/actions/workflows/buildstatus.yml/badge.svg">
+  <a href="https://www.gnu.org/licenses/agpl-3.0"><img alt="License: AGPL v3" src="https://img.shields.io/badge/License-AGPL_v3-blue.svg"></a>
+  <a href="https://pkg.go.dev/github.com/steffenfritz/FileTrove"><img alt="Go Reference" src="https://pkg.go.dev/badge/github.com/steffenfritz/FileTrove.svg"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/steffenfritz/FileTrove"><img alt="OpenSSF Scorecard" src="https://api.scorecard.dev/projects/github.com/steffenfritz/FileTrove/badge"></a>
+  <a href="https://www.bestpractices.dev/projects/8952"><img alt="OpenSSF Best Practices" src="https://www.bestpractices.dev/projects/8952/badge"></a>
+</p>
 
+**VERSION: v1.0.0-BETA-4**
 
-VERSION: v1.0.0-BETA-4
+---
 
-## About
+FileTrove walks a directory tree, identifies every file, computes metadata, and writes all results into a SQLite database with TSV export support.
 
-FileTrove indexes files and creates metadata from them.
+## What it collects
 
-The application walks a directory tree and identifies all regular files by type with [siegfried](https://github.com/richardlehane/siegfried), giving you the
+| Category | Details |
+|----------|---------|
+| **File type** | MIME type, [PRONOM](https://www.nationalarchives.gov.uk/PRONOM/) identifier, format version, identification proof/note, extension — via [siegfried](https://github.com/richardlehane/siegfried) |
+| **File & directory timestamps** | Creation, modification, and access times |
+| **Hashes** | MD5, SHA1, SHA256, SHA512, BLAKE2B-512 |
+| **Entropy** | Shannon entropy (files up to 1 GB) |
+| **Extended attributes** | xattr from ext3/ext4, btrfs, APFS, and others |
+| **EXIF metadata** | Extracted from image files |
+| **YARA-X** | Match results from your own rule files |
+| **NSRL** | Flags known software files via the [National Software Reference Library](https://www.nist.gov/itl/ssd/software-quality-group/national-software-reference-library-nsrl) |
+| **Dublin Core** | Optional session-level descriptive metadata |
 
-* MIME type
-* [PRONOM](https://www.nationalarchives.gov.uk/PRONOM/) identifier
-* Format version
-* Identification proof and note
-* filename extension
+Each file and directory gets a UUIDv4 as a unique identifier. All results land in a SQLite database and can be exported to TSV.
 
-os.Stat() is giving you the
+## Installation
 
-* File size
-* File creation time
-* File modification time
-* File access time
+1. **Get the binary** — download a release from the [releases page](https://github.com/steffenfritz/FileTrove/releases), or compile from source (see [BUILDING.md](BUILDING.md)). Both a standard dynamic binary (`ftrove`) and a static binary (e.g. `ftrove_amd64_linux_static`) are provided.
 
-* and the same for directories
+2. **Run the installer** from the directory where you want FileTrove to live:
+   ```sh
+   ./ftrove --install .
+   ```
+   This creates a `db/` directory, downloads the siegfried signature database, and optionally downloads the NSRL database (1.4 GB compressed). If you already have an NSRL database, copy it into `db/` afterwards.
 
-FileTrove also reads and indexes extended attributes (xattr) from ext3/ext4, btrfs, APFS, ...
+3. **You're ready.**
 
-Furthermore it creates and calculates
+### YARA-X
 
-* UUIDv4s as unique identifiers (not stable across sessions)
-* hash sums (md5, sha1, sha256, sha512 and blake2b-512)
-* the entropy of each file (up to 1GB)
+YARA-X scanning requires a C library that is not bundled with FileTrove. It is built automatically during `task build` if not already present. See [BUILDING.md](BUILDING.md) for setup instructions.
 
-* and it extracts some EXIF metadata and
-* you can add your own [DublinCore Elements](https://www.dublincore.org/specifications/dublin-core/usageguide/elements/) metadata to scans.
+- Example rule files: `testdata/yara/`
+- When a rule matches, the rule name, session UUID, and file UUID are recorded in the `yara` table. The rule file itself is not stored.
 
-* A very powerful feature is FileTrove's ability to consume [YARA-X](https://virustotal.github.io/yara-x/) rule files.
+### NSRL custom databases
 
-* FileTrove also checks if the file is in the [NSRL](https://www.nist.gov/itl/ssd/software-quality-group/national-software-reference-library-nsrl).
+You can build your own NSRL-style database from any newline-delimited list of SHA1 hashes using `admftrove`, which is built alongside `ftrove`.
 
-For this check a 4.0GB BoltDB is needed and can be downloaded with FileTrove during the installation.
+## Running a scan
 
-You can also create your own database for the NSRL check. You just need a text file with SHA1 hashes, one per line and the tool `admftrove` which is built along with `ftrove`. With this tool you can also add your own hashes to an existing database.
+```sh
+./ftrove -i $DIRECTORY
+```
 
-All results are written into a SQLite database and can be exported to TSV files.
+FileTrove walks `$DIRECTORY` recursively. Run `./ftrove -h` for all available flags.
 
-## How to install
-1. Download a release from https://github.com/steffenfritz/FileTrove/releases or compile from source (using `task build` in the repository root).
-   - This will generate both a standard dynamic binary (`ftrove`) and a standalone static binary (e.g., `ftrove_amd64_linux_static`).
-2. Copy the binary you wish to use where you want to install ftrove (the downloaded file has a suffix, omitted in the following documentation)
-3. Run `./ftrove --install .` (Mind the period)
+## Viewing results
 
-	a) If you don't have already a NSRL database, you have to download it. Please be patient.
+List all sessions and export one to TSV:
 
-	b) If you have a NSRL database copy/move it to the "db" directory that ftrove just created.
+```sh
+./ftrove -l
+./ftrove -t 926be141-ab75-4106-8236-34edfcf102f2
+```
 
-4. You are ready to go!
+You can also query the SQLite database directly:
 
-### A word on YARA
-The YARA module needs a C library that is not part of FileTrove.
-It is now automatically built and installed during the `task build` process if it's not already present on your system.
-
-A YARA example rule file can be found in the testdata/yara directory in this repository.
-
-If a rule matches on a file the rule name, the session UUID and the file UUID is written into the table _yara_.
-
-The YARA rule file itself is not stored in FileTrove's database.
-
-### To compile FileTrove with YARA-X support
-
-See [BUILDING.md](BUILDING.md) for step-by-step setup instructions on macOS and Debian/Ubuntu.
-
-## How to run
-
-`./ftrove -h` gives you all flags ftrove understands.
-
-A run only with necessary flags looks like this:
-
-`./ftrove -i $DIRECTORY`
-
-where $DIRECTORY is a directory you want to use as a starting point. FileTrove will walk this directory recursively down.
-
-## How to see the results
-
-You can export the results via `./ftrove -t $UUID` where $UUID is the session id.
-Every indexing run gets its own session id. You get a list of all sessions using `./ftrove -l`.
-
-Example:
-
-1. `./ftrove -l`
-2. `./ftrove -t 926be141-ab75-4106-8236-34edfcf102f2`
-
-This will create several TSV files that can be read with Excel, Numbers and your preferred text editor.
-
-You can also work with SQL on the database, using sqlite on the console or a GUI like sqlitebrowser (<https://sqlitebrowser.org/>). Sqliteviz is also a neat tool to visualize the data (<https://sqliteviz.com/app/#/>).
+- **CLI:** `sqlite3 db/filetrove.db`
+- **GUI:** [sqlitebrowser](https://sqlitebrowser.org/)
+- **Visualisation:** [Sqliteviz](https://sqliteviz.com/app/#/)
 
 ## Background
 
-FileTrove is the successor of [filedriller](https://github.com/steffenfritz/filedriller) and based on my iPres 2021 paper [Marrying siegfried and the National Software Reference Library](https://phaidra.univie.ac.at/detail/o:1424904)
+FileTrove is the successor of [filedriller](https://github.com/steffenfritz/filedriller), based on the iPres 2021 paper [Marrying siegfried and the National Software Reference Library](https://phaidra.univie.ac.at/detail/o:1424904).

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,5 +1,7 @@
 version: '3'
 
+dotenv: ['cmd/ftrove/.yara_env']
+
 vars:
   VERSION:
     sh: cat VERSION

--- a/cmd/ftrove/Taskfile.yml
+++ b/cmd/ftrove/Taskfile.yml
@@ -100,7 +100,8 @@ tasks:
         PC_DIR=$(dirname "$PC_FILE")
         LIB_DIR=$(find $HOME/yara_install -name "libyara_x_capi*" -exec dirname {} \; | head -1)
         echo "PKG_CONFIG_PATH=$PC_DIR" > .yara_env
-        echo "CGO_CFLAGS=-I$(dirname "$LIB_DIR")/include" >> .yara_env
+        PREFIX=$(PKG_CONFIG_PATH=$PC_DIR pkg-config --variable=prefix yara_x_capi)
+        echo "CGO_CFLAGS=-I$HOME/yara_install$PREFIX/include" >> .yara_env
         echo "CGO_LDFLAGS=-L$LIB_DIR" >> .yara_env
         echo "Setup complete. YARA-X env written to cmd/ftrove/.yara_env and will be auto-loaded by task."
 
@@ -135,7 +136,8 @@ tasks:
         PC_DIR=$(dirname "$PC_FILE")
         LIB_DIR=$(find $HOME/yara_install -name "libyara_x_capi*" -exec dirname {} \; | head -1)
         echo "PKG_CONFIG_PATH=$PC_DIR" > .yara_env
-        echo "CGO_CFLAGS=-I$(dirname "$LIB_DIR")/include" >> .yara_env
+        PREFIX=$(PKG_CONFIG_PATH=$PC_DIR pkg-config --variable=prefix yara_x_capi)
+        echo "CGO_CFLAGS=-I$HOME/yara_install$PREFIX/include" >> .yara_env
         echo "CGO_LDFLAGS=-L$LIB_DIR" >> .yara_env
         echo "Setup complete. YARA-X env written to cmd/ftrove/.yara_env and will be auto-loaded by task."
 

--- a/cmd/ftrove/Taskfile.yml
+++ b/cmd/ftrove/Taskfile.yml
@@ -6,6 +6,8 @@ vars:
   GIT_COMMIT:
     sh: git log -n 1 --format=%h
 
+dotenv: ['.yara_env']
+
 env:
   CGO_ENABLED: "1"
 

--- a/cmd/ftrove/Taskfile.yml
+++ b/cmd/ftrove/Taskfile.yml
@@ -6,8 +6,6 @@ vars:
   GIT_COMMIT:
     sh: git log -n 1 --format=%h
 
-dotenv: ['.yara_env']
-
 env:
   CGO_ENABLED: "1"
 

--- a/cmd/ftrove/Taskfile.yml
+++ b/cmd/ftrove/Taskfile.yml
@@ -77,6 +77,70 @@ tasks:
       CC: "zig cc -target x86_64-windows-musl"
       CXX: "zig cc -target x86_64-windows-musl"
 
+  setup_mac:
+    desc: Install all development dependencies on macOS and build the YARA-X C library
+    cmds:
+      - command -v go          >/dev/null 2>&1 || brew install go
+      - command -v cargo       >/dev/null 2>&1 || brew install rust
+      - command -v zig         >/dev/null 2>&1 || brew install zig
+      - command -v sqlite3     >/dev/null 2>&1 || brew install sqlite
+      - command -v pkg-config  >/dev/null 2>&1 || brew install pkg-config
+      - command -v cargo-cinstall >/dev/null 2>&1 || cargo install cargo-c
+      - |
+        if [ ! -d "$HOME/yara-x" ]; then
+          git clone --depth 1 --branch v1.14.0 https://github.com/VirusTotal/yara-x.git $HOME/yara-x
+        fi
+      - |
+        if [ ! -d "$HOME/yara_install" ]; then
+          cd $HOME/yara-x
+          cargo cinstall -p yara-x-capi --release --destdir=$HOME/yara_install
+        fi
+      - |
+        PC_FILE=$(find $HOME/yara_install -name yara_x_capi.pc | head -1)
+        PC_DIR=$(dirname "$PC_FILE")
+        LIB_DIR=$(find $HOME/yara_install -name "libyara_x_capi*" -exec dirname {} \; | head -1)
+        INC_DIR=$(find $HOME/yara_install -name "yara_x_capi.h" -exec dirname {} \; | head -1)
+        echo "PKG_CONFIG_PATH=$PC_DIR" > .yara_env
+        echo "CGO_CFLAGS=-I$INC_DIR" >> .yara_env
+        echo "CGO_LDFLAGS=-L$LIB_DIR" >> .yara_env
+        echo "Setup complete. YARA-X env written to cmd/ftrove/.yara_env and will be auto-loaded by task."
+
+  setup_linux:
+    desc: Install all development dependencies on Debian/Ubuntu and build the YARA-X C library
+    cmds:
+      - |
+        pkgs=""
+        command -v gcc        >/dev/null 2>&1 || pkgs="$pkgs build-essential"
+        command -v git        >/dev/null 2>&1 || pkgs="$pkgs git"
+        command -v curl       >/dev/null 2>&1 || pkgs="$pkgs curl"
+        command -v pkg-config >/dev/null 2>&1 || pkgs="$pkgs pkg-config"
+        command -v sqlite3    >/dev/null 2>&1 || pkgs="$pkgs sqlite3"
+        command -v go         >/dev/null 2>&1 || pkgs="$pkgs golang"
+        if [ -n "$pkgs" ]; then sudo apt update && sudo apt install -y $pkgs; fi
+      - command -v cargo >/dev/null 2>&1 || (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y)
+      - |
+        source "$HOME/.cargo/env"
+        command -v cargo-cinstall >/dev/null 2>&1 || cargo install cargo-c
+      - |
+        if [ ! -d "$HOME/yara-x" ]; then
+          git clone --depth 1 --branch v1.14.0 https://github.com/VirusTotal/yara-x.git $HOME/yara-x
+        fi
+      - |
+        if [ ! -d "$HOME/yara_install" ]; then
+          source "$HOME/.cargo/env"
+          cd $HOME/yara-x
+          cargo cinstall -p yara-x-capi --release --destdir=$HOME/yara_install
+        fi
+      - |
+        PC_FILE=$(find $HOME/yara_install -name yara_x_capi.pc | head -1)
+        PC_DIR=$(dirname "$PC_FILE")
+        LIB_DIR=$(find $HOME/yara_install -name "libyara_x_capi*" -exec dirname {} \; | head -1)
+        INC_DIR=$(find $HOME/yara_install -name "yara_x_capi.h" -exec dirname {} \; | head -1)
+        echo "PKG_CONFIG_PATH=$PC_DIR" > .yara_env
+        echo "CGO_CFLAGS=-I$INC_DIR" >> .yara_env
+        echo "CGO_LDFLAGS=-L$LIB_DIR" >> .yara_env
+        echo "Setup complete. YARA-X env written to cmd/ftrove/.yara_env and will be auto-loaded by task."
+
   clean:
     desc: Delete builds and test files
     cmds:

--- a/cmd/ftrove/Taskfile.yml
+++ b/cmd/ftrove/Taskfile.yml
@@ -99,9 +99,8 @@ tasks:
         PC_FILE=$(find $HOME/yara_install -name yara_x_capi.pc | head -1)
         PC_DIR=$(dirname "$PC_FILE")
         LIB_DIR=$(find $HOME/yara_install -name "libyara_x_capi*" -exec dirname {} \; | head -1)
-        INC_DIR=$(find $HOME/yara_install -name "yara_x_capi.h" -exec dirname {} \; | head -1)
         echo "PKG_CONFIG_PATH=$PC_DIR" > .yara_env
-        echo "CGO_CFLAGS=-I$INC_DIR" >> .yara_env
+        echo "CGO_CFLAGS=-I$(dirname "$LIB_DIR")/include" >> .yara_env
         echo "CGO_LDFLAGS=-L$LIB_DIR" >> .yara_env
         echo "Setup complete. YARA-X env written to cmd/ftrove/.yara_env and will be auto-loaded by task."
 
@@ -135,9 +134,8 @@ tasks:
         PC_FILE=$(find $HOME/yara_install -name yara_x_capi.pc | head -1)
         PC_DIR=$(dirname "$PC_FILE")
         LIB_DIR=$(find $HOME/yara_install -name "libyara_x_capi*" -exec dirname {} \; | head -1)
-        INC_DIR=$(find $HOME/yara_install -name "yara_x_capi.h" -exec dirname {} \; | head -1)
         echo "PKG_CONFIG_PATH=$PC_DIR" > .yara_env
-        echo "CGO_CFLAGS=-I$INC_DIR" >> .yara_env
+        echo "CGO_CFLAGS=-I$(dirname "$LIB_DIR")/include" >> .yara_env
         echo "CGO_LDFLAGS=-L$LIB_DIR" >> .yara_env
         echo "Setup complete. YARA-X env written to cmd/ftrove/.yara_env and will be auto-loaded by task."
 


### PR DESCRIPTION
  ### Developer onboarding (`BUILDING.md`, `cmd/ftrove/Taskfile.yml`, `Taskfile.yml`)
  - Added `BUILDING.md` with step-by-step setup instructions for macOS and Debian/Ubuntu
  - Added `task setup_mac` and `task setup_linux` to `cmd/ftrove/Taskfile.yml` — single-command setup that installs all dependencies (Go, Rust, Zig, pkg-config, sqlite3, cargo-c), builds the YARA-X C library into
  `$HOME/yara_install`, and writes CGO env vars to `cmd/ftrove/.yara_env`
  - Added `dotenv: ['cmd/ftrove/.yara_env']` to root `Taskfile.yml` so the YARA-X env vars are auto-loaded by all subsequent `task` invocations (avoids triggering the system-wide `sudo` install path)
  - Added `cmd/ftrove/.yara_env` to `.gitignore`
  - Replaced verbose inline build instructions in `README.md` with a pointer to `BUILDING.md`

  ### CGO include path fix (`cmd/ftrove/Taskfile.yml`, `buildstatus.yml`)
  - Fixed `CGO_CFLAGS` derivation: use `pkg-config --variable=prefix` to get the install prefix from the `.pc` file, then prepend the destdir (`$HOME/yara_install`). This correctly resolves to
  `$HOME/yara_install/usr/local/include` on both macOS (flat `lib/`) and Linux (arch-specific `lib/x86_64-linux-gnu/`), avoiding the `yara_x.h: No such file or directory` build failure

  ### CI: add macOS to build matrix (`buildstatus.yml`)
  - Added `macos-latest` to the runner matrix alongside `ubuntu-latest` and `windows-latest`
  - Merged the Linux-only YARA-X build step into a shared `Linux/macOS` step (`runner.os != 'Windows'`)
  - Same for `cargo-c` install step

  ### GitHub Actions runner updates (all workflow files)
  - `step-security/harden-runner`: `v2.15.1` → `v2.16.0`
  - `actions/cache`: `v5.0.3` → `v5.0.4`
  - `go-task/setup-task`: `v1` → `v1.1.0`
  - `github/codeql-action` (init, analyze, upload-sarif): `v4.32.6` → `v4.33.0`
  - `codeql.yml`: pinned all previously floating `@v4` tags to full commit SHAs
  
I also adapted the README to all those changes and make it much smaller ([VIEW HERE](https://github.com/rhaist/FileTrove/blob/020ef320fbe83e03e2413ef372902b4d6ec7494a/README.md))