### PR TITLE
fix: harden filewalk and version compatibility check

### DIFF
--- a/cmd/ftrove/main.go
+++ b/cmd/ftrove/main.go
@@ -399,7 +399,7 @@ func main() {
 	}
 
 	// Create file list
-	filelist, dirlist, err := ft.CreateFileList(*inDir)
+	filelist, dirlist, skippedlist, err := ft.CreateFileList(*inDir)
 	if *debug {
 		ft.DebugWriteFileList(fddebug, filelist, dirlist)
 	}
@@ -410,6 +410,9 @@ func main() {
 			logger.Error("Could not close database connection to FileTrove.", slog.String("error", err.Error()))
 		}
 		os.Exit(1)
+	}
+	for _, skipped := range skippedlist {
+		logger.Warn("Skipped entry (symlink, special file, or inaccessible path).", slog.String("path", skipped))
 	}
 
 	// If we resumeuuid, we update the file list to start with the file after the last entry

--- a/filewalk.go
+++ b/filewalk.go
@@ -5,23 +5,44 @@ import (
 	"path/filepath"
 )
 
-// CreateFileList creates a list of file paths and a directory listing
-func CreateFileList(rootDir string) ([]string, []string, error) {
+// CreateFileList walks rootDir and returns three lists: regular files, directories, and skipped paths.
+//
+// Skipped paths include symlinks (not followed), special files (sockets, devices, FIFOs),
+// and any path that could not be accessed (e.g. permission denied, stale network mount).
+// The walk continues past inaccessible entries rather than aborting.
+//
+// Note: filepath.WalkDir crosses filesystem boundaries, including mounted network shares.
+// Callers that need to stay within a single device should compare the device ID of each
+// entry (via DirEntry.Info().Sys()) against the root device.
+func CreateFileList(rootDir string) ([]string, []string, []string, error) {
 	var fileList []string
 	var dirList []string
+	var skippedList []string
+
 	err := filepath.WalkDir(rootDir, func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
-			return err
+			// Inaccessible entry (permission denied, stale NFS mount, etc.).
+			// Record and continue rather than aborting the whole walk.
+			skippedList = append(skippedList, path)
+			return nil
 		}
-		if !info.IsDir() && info.Type().IsRegular() {
+
+		switch {
+		case info.Type().IsRegular():
 			fileList = append(fileList, path)
-		} else if info.IsDir() {
+		case info.IsDir():
 			dirList = append(dirList, path)
+		case info.Type()&fs.ModeSymlink != 0:
+			// Symlinks are not followed by filepath.WalkDir. Record them so
+			// callers are aware they exist on the filesystem.
+			skippedList = append(skippedList, path)
+		default:
+			// Special files: sockets, named pipes, device nodes.
+			skippedList = append(skippedList, path)
 		}
+
 		return nil
 	})
-	if err != nil {
-		return fileList, dirList, err
-	}
-	return fileList, dirList, nil
+
+	return fileList, dirList, skippedList, err
 }

--- a/filewalk_test.go
+++ b/filewalk_test.go
@@ -10,28 +10,60 @@ func TestCreateFileList(t *testing.T) {
 		rootDir string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    []string
-		want1   []string
-		wantErr bool
+		name        string
+		args        args
+		want        []string
+		want1       []string
+		wantSkipped []string
+		wantErr     bool
 	}{
-		{"testdata file list", args{"testdata"}, []string{"testdata/.hiddendir/.gitkeep", "testdata/.hiddenfile",
-			"testdata/directory/A_PDF_File.pdf", "testdata/dublincore_ex.json", "testdata/emptyfile.txt", "testdata/images/screenshot_1.jpeg", "testdata/images/screenshot_1.jpeg_original", "testdata/images/screenshot_1.png", "testdata/images/screenshot_1.png_original", "testdata/images/screenshot_1.tiff", "testdata/images/screenshot_1.tiff_original", "testdata/noaccess.rtf", "testdata/noextension", "testdata/textfile.txt", "testdata/transparent.png", "testdata/white.jpg", "testdata/yara/testrule.yara"},
-			[]string{"testdata", "testdata/.hiddendir", "testdata/directory", "testdata/images", "testdata/yara"}, false},
+		{
+			name: "testdata file list",
+			args: args{"testdata"},
+			want: []string{
+				"testdata/.hiddendir/.gitkeep",
+				"testdata/.hiddenfile",
+				"testdata/directory/A_PDF_File.pdf",
+				"testdata/dublincore_ex.json",
+				"testdata/emptyfile.txt",
+				"testdata/images/screenshot_1.jpeg",
+				"testdata/images/screenshot_1.jpeg_original",
+				"testdata/images/screenshot_1.png",
+				"testdata/images/screenshot_1.png_original",
+				"testdata/images/screenshot_1.tiff",
+				"testdata/images/screenshot_1.tiff_original",
+				"testdata/noextension",
+				"testdata/textfile.txt",
+				"testdata/transparent.png",
+				"testdata/white.jpg",
+				"testdata/yara/testrule.yara",
+			},
+			want1: []string{
+				"testdata",
+				"testdata/.hiddendir",
+				"testdata/directory",
+				"testdata/images",
+				"testdata/yara",
+			},
+			wantSkipped: nil,
+			wantErr:     false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1, err := CreateFileList(tt.args.rootDir)
+			got, got1, gotSkipped, err := CreateFileList(tt.args.rootDir)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CreateFileList() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("CreateFileList() got = %v, want %v", got, tt.want)
+				t.Errorf("CreateFileList() files = %v, want %v", got, tt.want)
 			}
 			if !reflect.DeepEqual(got1, tt.want1) {
-				t.Errorf("CreateFileList() got1 = %v, want %v", got1, tt.want1)
+				t.Errorf("CreateFileList() dirs = %v, want %v", got1, tt.want1)
+			}
+			if !reflect.DeepEqual(gotSkipped, tt.wantSkipped) {
+				t.Errorf("CreateFileList() skipped = %v, want %v", gotSkipped, tt.wantSkipped)
 			}
 		})
 	}

--- a/version.go
+++ b/version.go
@@ -3,10 +3,13 @@ package filetrove
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 )
 
-// CheckVersion checks if the filetrove version is compatible to the database
-// Compatible means same version for now. This could change in the future.
+// CheckVersion checks if the binary version is compatible with the database.
+// Only the base version (the part before '+') is compared, so that builds
+// from different commits but the same release (e.g. 1.0.0-BETA-4+abc vs
+// 1.0.0-BETA-4+def) are treated as compatible.
 func CheckVersion(db *sql.DB, version string) (bool, string, error) {
 	var dbversion string
 
@@ -18,7 +21,10 @@ func CheckVersion(db *sql.DB, version string) (bool, string, error) {
 		return false, "", err
 	}
 
-	if dbversion == version {
+	baseVersion := strings.SplitN(version, "+", 2)[0]
+	baseDbVersion := strings.SplitN(dbversion, "+", 2)[0]
+
+	if baseDbVersion == baseVersion {
 		return true, "", nil
 	}
 


### PR DESCRIPTION
  CreateFileList now continues past inaccessible entries (permission
  denied, stale NFS mounts) instead of aborting the whole walk, and
  returns a third skipped list covering symlinks, special files
  (sockets, devices, FIFOs), and any path that could not be stat'd.
  Skipped paths are logged as warnings by the caller.

  CheckVersion now strips the build commit suffix (the '+<hash>' part)
  before comparing versions, so databases created by different builds
  of the same release are no longer rejected as incompatible.