### PR TITLE
fix: add Rust minimum version check to setup tasks (fixes #157)

### DIFF
--- a/cmd/ftrove/Taskfile.yml
+++ b/cmd/ftrove/Taskfile.yml
@@ -114,7 +114,22 @@ tasks:
     desc: Install all development dependencies on macOS and build the YARA-X C library
     cmds:
       - command -v go          >/dev/null 2>&1 || brew install go
-      - command -v cargo       >/dev/null 2>&1 || brew install rust
+      - |
+        # yara-x v1.14+ requires Rust edition 2024 (stabilised in Rust 1.85 / Cargo 1.85).
+        # Install cargo if missing; upgrade if the detected version is too old.
+        if ! command -v cargo >/dev/null 2>&1; then
+          brew install rust
+        else
+          CARGO_MINOR=$(cargo --version | awk '{print $2}' | cut -d. -f2)
+          if [ "$CARGO_MINOR" -lt 85 ]; then
+            echo "cargo $(cargo --version | awk '{print $2}') is too old (need >= 1.85). Upgrading via rustup or brew..."
+            if command -v rustup >/dev/null 2>&1; then
+              rustup update stable
+            else
+              brew upgrade rust
+            fi
+          fi
+        fi
       - command -v zig         >/dev/null 2>&1 || brew install zig
       - command -v sqlite3     >/dev/null 2>&1 || brew install sqlite
       - command -v pkg-config  >/dev/null 2>&1 || brew install pkg-config
@@ -150,7 +165,17 @@ tasks:
         command -v sqlite3    >/dev/null 2>&1 || pkgs="$pkgs sqlite3"
         command -v go         >/dev/null 2>&1 || pkgs="$pkgs golang"
         if [ -n "$pkgs" ]; then sudo apt update && sudo apt install -y $pkgs; fi
-      - command -v cargo >/dev/null 2>&1 || (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y)
+      - |
+        # yara-x v1.14+ requires Rust edition 2024 (stabilised in Rust 1.85 / Cargo 1.85).
+        if ! command -v cargo >/dev/null 2>&1; then
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        else
+          CARGO_MINOR=$(cargo --version | awk '{print $2}' | cut -d. -f2)
+          if [ "$CARGO_MINOR" -lt 85 ]; then
+            echo "cargo $(cargo --version | awk '{print $2}') is too old (need >= 1.85). Running: rustup update stable"
+            rustup update stable
+          fi
+        fi
       - |
         source "$HOME/.cargo/env"
         command -v cargo-cinstall >/dev/null 2>&1 || cargo install cargo-c

--- a/cmd/ftrove/Taskfile.yml
+++ b/cmd/ftrove/Taskfile.yml
@@ -122,12 +122,14 @@ tasks:
       - |
         # yara-x v1.14+ requires Rust edition 2024 (stabilised in Rust 1.85 / Cargo 1.85).
         # Install cargo if missing; upgrade if the detected version is too old.
+        # Use grep -oE to extract the semver reliably (Homebrew appends a commit hash to the output).
         if ! command -v cargo >/dev/null 2>&1; then
           brew install rust
         else
-          CARGO_MINOR=$(cargo --version | awk '{print $2}' | cut -d. -f2)
+          CARGO_VERSION=$(cargo --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          CARGO_MINOR=$(echo "$CARGO_VERSION" | cut -d. -f2)
           if [ "$CARGO_MINOR" -lt 85 ]; then
-            echo "cargo $(cargo --version | awk '{print $2}') is too old (need >= 1.85). Upgrading via rustup or brew..."
+            echo "cargo $CARGO_VERSION is too old (need >= 1.85). Upgrading via rustup or brew..."
             if command -v rustup >/dev/null 2>&1; then
               rustup update stable
             else
@@ -138,23 +140,31 @@ tasks:
       - command -v zig         >/dev/null 2>&1 || brew install zig
       - command -v sqlite3     >/dev/null 2>&1 || brew install sqlite
       - command -v pkg-config  >/dev/null 2>&1 || brew install pkg-config
-      - command -v cargo-cinstall >/dev/null 2>&1 || cargo install cargo-c
       - |
-        if [ ! -d "$HOME/yara-x" ]; then
-          git clone --depth 1 --branch v1.14.0 https://github.com/VirusTotal/yara-x.git $HOME/yara-x
-        fi
-      - |
-        if [ ! -d "$HOME/yara_install" ]; then
+        # Skip the source build entirely if yara_x_capi is already available (e.g. via brew install yara-x)
+        if pkg-config --exists yara_x_capi 2>/dev/null; then
+          echo "yara_x_capi already available via pkg-config, skipping source build."
+        else
+          command -v cargo-cinstall >/dev/null 2>&1 || cargo install cargo-c
+          if [ ! -d "$HOME/yara-x" ]; then
+            git clone --depth 1 --branch v1.14.0 https://github.com/VirusTotal/yara-x.git $HOME/yara-x
+          fi
           cd $HOME/yara-x
           cargo cinstall -p yara-x-capi --release --destdir=$HOME/yara_install
         fi
       - |
-        PC_FILE=$(find $HOME/yara_install -name yara_x_capi.pc | head -1)
-        PC_DIR=$(dirname "$PC_FILE")
-        LIB_DIR=$(find $HOME/yara_install -name "libyara_x_capi*" -exec dirname {} \; | head -1)
+        if pkg-config --exists yara_x_capi 2>/dev/null; then
+          PC_DIR=$(pkg-config --variable=pcfiledir yara_x_capi)
+          LIB_DIR=$(pkg-config --variable=libdir yara_x_capi)
+          PREFIX=$(pkg-config --variable=prefix yara_x_capi)
+        else
+          PC_FILE=$(find $HOME/yara_install -name yara_x_capi.pc | head -1)
+          PC_DIR=$(dirname "$PC_FILE")
+          LIB_DIR=$(find $HOME/yara_install -name "libyara_x_capi*" -exec dirname {} \; | head -1)
+          PREFIX=$(PKG_CONFIG_PATH=$PC_DIR pkg-config --variable=prefix yara_x_capi)
+        fi
         echo "PKG_CONFIG_PATH=$PC_DIR" > .yara_env
-        PREFIX=$(PKG_CONFIG_PATH=$PC_DIR pkg-config --variable=prefix yara_x_capi)
-        echo "CGO_CFLAGS=-I$HOME/yara_install$PREFIX/include" >> .yara_env
+        echo "CGO_CFLAGS=-I${PREFIX}/include" >> .yara_env
         echo "CGO_LDFLAGS=-L$LIB_DIR" >> .yara_env
         echo "Setup complete. YARA-X env written to cmd/ftrove/.yara_env and will be auto-loaded by task."
 
@@ -172,12 +182,14 @@ tasks:
         if [ -n "$pkgs" ]; then sudo apt update && sudo apt install -y $pkgs; fi
       - |
         # yara-x v1.14+ requires Rust edition 2024 (stabilised in Rust 1.85 / Cargo 1.85).
+        # Use grep -oE to extract the semver reliably (some distributions append extra info to the output).
         if ! command -v cargo >/dev/null 2>&1; then
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         else
-          CARGO_MINOR=$(cargo --version | awk '{print $2}' | cut -d. -f2)
+          CARGO_VERSION=$(cargo --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          CARGO_MINOR=$(echo "$CARGO_VERSION" | cut -d. -f2)
           if [ "$CARGO_MINOR" -lt 85 ]; then
-            echo "cargo $(cargo --version | awk '{print $2}') is too old (need >= 1.85). Running: rustup update stable"
+            echo "cargo $CARGO_VERSION is too old (need >= 1.85). Running: rustup update stable"
             rustup update stable
           fi
         fi

--- a/cmd/ftrove/Taskfile.yml
+++ b/cmd/ftrove/Taskfile.yml
@@ -33,8 +33,13 @@ tasks:
       # -tags static_link is required for yara-x go bindings to use --static pkg-config
       # The extra -extldflags libs are required by CGO (go-sqlite3, yara-x-capi) when linking statically on Linux
       - |
+        # Go's CGO linker adds -lgcc_s which only exists as a shared lib; we provide an empty stub archive so the
+        # linker is satisfied (actual symbols come from the static -lgcc which is always available)
         if [ "{{OS}}" = "linux" ]; then
-          go build -tags static_link -ldflags "-X main.Version={{.VERSION}}+{{.GIT_COMMIT}} -w -s -extldflags '-static -static-libgcc -lm -ldl -lpthread -lrt -lutil'" -o ftrove_{{ARCH}}_{{OS}}_static
+          STUBDIR=$(mktemp -d)
+          ar rcs "$STUBDIR/libgcc_s.a"
+          go build -tags static_link -ldflags "-X main.Version={{.VERSION}}+{{.GIT_COMMIT}} -w -s -extldflags '-static -lm -ldl -lpthread -lrt -lutil -L$STUBDIR'" -o ftrove_{{ARCH}}_{{OS}}_static
+          rm -rf "$STUBDIR"
         else
           go build -tags static_link -ldflags "-X main.Version={{.VERSION}}+{{.GIT_COMMIT}} -w -s" -o ftrove_{{ARCH}}_{{OS}}_static
         fi

--- a/cmd/ftrove/Taskfile.yml
+++ b/cmd/ftrove/Taskfile.yml
@@ -34,7 +34,7 @@ tasks:
       # The extra -extldflags libs are required by CGO (go-sqlite3, yara-x-capi) when linking statically on Linux
       - |
         if [ "{{OS}}" = "linux" ]; then
-          go build -tags static_link -ldflags "-X main.Version={{.VERSION}}+{{.GIT_COMMIT}} -w -s -extldflags '-static -lm -ldl -lpthread -lrt -lutil'" -o ftrove_{{ARCH}}_{{OS}}_static
+          go build -tags static_link -ldflags "-X main.Version={{.VERSION}}+{{.GIT_COMMIT}} -w -s -extldflags '-static -static-libgcc -lm -ldl -lpthread -lrt -lutil'" -o ftrove_{{ARCH}}_{{OS}}_static
         else
           go build -tags static_link -ldflags "-X main.Version={{.VERSION}}+{{.GIT_COMMIT}} -w -s" -o ftrove_{{ARCH}}_{{OS}}_static
         fi


### PR DESCRIPTION
## Summary

- **Rust version check**: `setup_mac` and `setup_linux` previously only installed Rust if `cargo` was absent, silently proceeding with any existing version. yara-x v1.14+ requires `edition2024`, stabilised in Rust/Cargo 1.85. Both tasks now detect an outdated Cargo and upgrade automatically.
- **Reliable version extraction**: The initial fix used `awk '{print $2}'` which breaks when Homebrew appends a commit hash to `cargo --version` output (e.g. `cargo 1.83.0 (adf9b6ad9 2024-10-14)`). Replaced with `grep -oE '[0-9]+\.[0-9]+\.[0-9]+'` to extract the semver reliably regardless of extra output.
- **Skip source build if already installed**: `setup_mac` now checks `pkg-config --exists yara_x_capi` before cloning/building from source. Users with `brew install yara-x` already installed skip the source build entirely and use their system library.
- **Linux static build**: Added empty `libgcc_s.a` stub at link time — Ubuntu ships `libgcc_s` as a shared library only; the stub satisfies the linker while actual symbols come from the always-available static `libgcc.a`.

## Test plan

- [ ] macOS with rustup cargo < 1.85: `task setup_mac` triggers `rustup update stable`
- [ ] macOS with Homebrew cargo < 1.85 (no rustup): `task setup_mac` triggers `brew upgrade rust`
- [ ] macOS with Homebrew cargo output including commit hash: version extraction correctly identifies the minor version
- [ ] macOS with `brew install yara-x` already present: `task setup_mac` skips clone/build, uses system pkg-config
- [ ] macOS with cargo >= 1.85 and no yara-x: full source build proceeds normally
- [ ] Linux static build (`build-static`) succeeds on Ubuntu (no `libgcc_s: No such file or directory` error)

Closes #157