### PR TITLE
Fix CGO_CFLAGS and static-link errors in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,17 +85,29 @@ jobs:
             echo "Error: yara_x_capi.pc not found"; exit 1
           fi
           PC_DIR=$(dirname "$PC_FILE")
-          LIB_DIR=$(find $HOME/yara_install -name "libyara_x_capi.so*" -exec dirname {} \; | sort -u | head -1)
+          LIB_DIR=$(find $HOME/yara_install -name "libyara_x_capi*" -exec dirname {} \; | head -1)
+          PREFIX=$(PKG_CONFIG_PATH=$PC_DIR pkg-config --variable=prefix yara_x_capi)
           echo "PKG_CONFIG_PATH=$PC_DIR" >> $GITHUB_ENV
-          echo "CGO_CFLAGS=-I$HOME/yara_install/usr/local/include" >> $GITHUB_ENV
+          echo "CGO_CFLAGS=-I$HOME/yara_install$PREFIX/include" >> $GITHUB_ENV
           echo "CGO_LDFLAGS=-L$LIB_DIR" >> $GITHUB_ENV
           echo "CGO_ENABLED=1" >> $GITHUB_ENV
 
       - name: Verify pkg-config
         run: pkg-config --cflags --libs yara_x_capi
 
-      - name: Build Go binaries
-        run: task build
+      - name: Build Go binaries (dynamic only)
+        # Build dynamic binaries only — the .deb package does not include static builds,
+        # and static linking with CGO requires libgcc_s.a which is absent on Ubuntu runners.
+        run: |
+          GIT_COMMIT=$(git log -n 1 --format=%h)
+          cd cmd/ftrove
+          go build -gcflags="-m" -buildmode=pie \
+            -ldflags "-X main.Version=${VERSION}+${GIT_COMMIT} -w -s" \
+            -o ftrove
+          cd ../../cmd/admftrove
+          go build \
+            -ldflags "-X main.Version=${VERSION}+${GIT_COMMIT} -w -s" \
+            -o admftrove
 
       - name: Install nfpm
         run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
@@ -177,10 +189,10 @@ jobs:
             echo "Error: yara_x_capi.pc not found"; exit 1
           fi
           PC_DIR=$(dirname "$PC_FILE")
-          LIB_DIR=$(find $HOME/yara_install -name "libyara_x_capi.dylib" -exec dirname {} \; | head -1)
-          INC_DIR=$(find $HOME/yara_install -name "yara_x_capi.h" -exec dirname {} \; | head -1)
+          LIB_DIR=$(find $HOME/yara_install -name "libyara_x_capi*" -exec dirname {} \; | head -1)
+          PREFIX=$(PKG_CONFIG_PATH=$PC_DIR pkg-config --variable=prefix yara_x_capi)
           echo "PKG_CONFIG_PATH=$PC_DIR" >> $GITHUB_ENV
-          echo "CGO_CFLAGS=-I$INC_DIR" >> $GITHUB_ENV
+          echo "CGO_CFLAGS=-I$HOME/yara_install$PREFIX/include" >> $GITHUB_ENV
           echo "CGO_LDFLAGS=-L$LIB_DIR" >> $GITHUB_ENV
           echo "CGO_ENABLED=1" >> $GITHUB_ENV
           echo "YARA_LIB_DIR=$LIB_DIR" >> $GITHUB_ENV
@@ -188,8 +200,18 @@ jobs:
       - name: Verify pkg-config
         run: pkg-config --cflags --libs yara_x_capi
 
-      - name: Build Go binaries
-        run: task build
+      - name: Build Go binaries (dynamic only)
+        # Build dynamic binaries only — macOS cannot produce a fully static CGO binary.
+        run: |
+          GIT_COMMIT=$(git log -n 1 --format=%h)
+          cd cmd/ftrove
+          go build -gcflags="-m" -buildmode=pie \
+            -ldflags "-X main.Version=${VERSION}+${GIT_COMMIT} -w -s" \
+            -o ftrove
+          cd ../../cmd/admftrove
+          go build \
+            -ldflags "-X main.Version=${VERSION}+${GIT_COMMIT} -w -s" \
+            -o admftrove
 
       - name: Bundle macOS archive
         run: |


### PR DESCRIPTION
## Summary

Fixes two bugs introduced with the release workflow that surfaced during pre-release test runs (`v1.0.0-beta.5`, `v1.0.0-beta.6`).

### macOS — `clang: error: no such file or directory: 'arm64'`

`CGO_CFLAGS` was set using `find ... -name "yara_x_capi.h"` to locate the include directory. On M-chip runners the YARA-X install prefix is not always `/usr/local`, so `find` returned empty, leaving `CGO_CFLAGS=-I` (a bare `-I` with no path). Clang then consumed the next flag (`-arch`) as the include path, with `arm64` left as a dangling file argument — exactly the error observed.

**Fix:** derive the include path from `pkg-config --variable=prefix`, which is the same approach already used in `buildstatus.yml` and the local `setup_mac` task.

### Linux (amd64 + arm64) — `cannot find -lgcc_s`

`task build` triggers the `build-static` subtask, which passes `-extldflags '-static ...'` to the external linker. That requires `libgcc_s.a` (the static GCC runtime), which Ubuntu runners do not ship. The `.deb` package only contains the dynamic binary, so the static build step is unnecessary in CI.

**Fix:** replace `task build` with direct `go build` commands that produce the dynamic binary only, skipping the static build entirely.

## Test plan

- [ ] Push a new pre-release tag to trigger the workflow
- [ ] Confirm all three jobs complete: `build-linux amd64`, `build-linux arm64`, `build-macos-arm64`
- [ ] Confirm the `release` job attaches all three assets to the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)