### PR TITLE
Fix pkg:stage destdir mismatch on Linux in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,14 @@ jobs:
 
       - name: Stage and package .deb
         run: |
-          task pkg:stage
+          # task pkg:stage uses `pkg-config --libs-only-L` which returns the prefix
+          # from the .pc file (/usr/local/lib/...), not the --destdir path used in CI.
+          # Derive the correct library directory from CGO_LDFLAGS instead.
+          LIB_DIR=$(echo "$CGO_LDFLAGS" | tr ' ' '\n' | grep '^-L' | head -1 | sed 's/^-L//')
+          mkdir -p dist/libs
+          cp cmd/ftrove/ftrove dist/
+          cp cmd/admftrove/admftrove dist/
+          cp -P "$LIB_DIR"/libyara_x_capi.so* dist/libs/
           "$(go env GOPATH)/bin/nfpm" package --packager deb --config nfpm.yaml --target dist/
 
       - name: Upload .deb artifact


### PR DESCRIPTION
task pkg:stage resolves the YARA-X library path via `pkg-config --libs-only-L`, which returns the prefix embedded in the .pc file (/usr/local/lib/...) — not the --destdir path used in CI ($HOME/yara_install/usr/local/lib/...).

Replace task pkg:stage with explicit staging that derives LIB_DIR from CGO_LDFLAGS, which is already set to the correct destdir- prefixed path by the YARA-X build step.