### PR TITLE
Warn when NSRL Bloom filter actual count exceeds estimate

### DIFF
--- a/nsrl.go
+++ b/nsrl.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/gob"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 
@@ -50,6 +51,15 @@ func CreateNSRLBloom(nsrlsourcefile string, nsrlversion string, nsrloutfile stri
 
 	if err := scanner.Err(); err != nil {
 		return err
+	}
+
+	fmt.Printf("Bloom filter stats: estimated items: %d, actual items inserted: %d, target FPR: %.6f\n",
+		estimatedItems, count, fpr)
+	if count > estimatedItems {
+		fmt.Printf("WARNING: actual item count (%d) exceeds estimated items (%d). "+
+			"The real false positive rate will be significantly higher than the target %.6f. "+
+			"Re-create the filter with --nsrl-estimate >= %d.\n",
+			count, estimatedItems, fpr, count)
 	}
 
 	nf := NSRLFilter{


### PR DESCRIPTION
## Summary

- Prints Bloom filter stats (estimated items, actual items inserted, target FPR) after `CreateNSRLBloom` completes
- Emits a clear `WARNING` with the recommended `--nsrl-estimate` value when actual item count exceeds the estimate
- The size mismatch is the primary cause of the elevated false positive rate reported in production

## Test plan

- [ ] Build `admftrove` and run `--create-nsrl` with a hash file larger than the estimate — verify warning is printed
- [ ] Run with a correctly sized estimate — verify only the stats line is printed, no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)