### PR TITLE
fix: skip unreadable files and named pipes in CreateFileList

### DIFF
--- a/filewalk.go
+++ b/filewalk.go
@@ -2,6 +2,7 @@ package filetrove
 
 import (
 	"io/fs"
+	"os"
 	"path/filepath"
 )
 
@@ -29,6 +30,12 @@ func CreateFileList(rootDir string) ([]string, []string, []string, error) {
 
 		switch {
 		case info.Type().IsRegular():
+			f, openErr := os.Open(path)
+			if openErr != nil {
+				skippedList = append(skippedList, path)
+				break
+			}
+			f.Close()
 			fileList = append(fileList, path)
 		case info.IsDir():
 			dirList = append(dirList, path)

--- a/filewalk_test.go
+++ b/filewalk_test.go
@@ -46,7 +46,7 @@ func TestCreateFileList(t *testing.T) {
 				"testdata/images",
 				"testdata/yara",
 			},
-			wantSkipped: nil,
+			wantSkipped: []string{"testdata/noaccess.rtf", "testdata/testpipe"},
 			wantErr:     false,
 		},
 	}


### PR DESCRIPTION
Regular files that cannot be opened (e.g. permission denied) are now added to skippedList instead of fileList. Named pipes were already routed to skippedList via the default case; the test expectation is updated to reflect both entries.