### PR TITLE
feat: variant-specific NSRL bloom filter filenames

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -103,7 +103,7 @@ This builds both binaries, downloads `siegfried.sig`, and packages everything in
 
 ```sh
 cd build/darwin_arm64         # or linux_amd64, etc.
-./ftrove --install .          # creates filetrove.db, logs/, downloads nsrl.bloom
+./ftrove --install .          # creates filetrove.db, logs/, downloads nsrl-<variant>.bloom
 ./ftrove -i /path/to/files
 ```
 
@@ -150,6 +150,31 @@ task nsrl:check
 ```
 
 To update to a new NIST release: bump `NSRL_VERSION` in `Taskfile.nsrl.yml` to the latest [NIST RDS release](https://www.nist.gov/itl/ssd/software-quality-group/national-software-reference-library-nsrl/nsrl-download/current-rds), run `task nsrl:clean`, rebuild all three variants, upload them to a new GitHub Release tag, and update the URL constants in `install.go`.
+
+### Publishing bloom files to GitHub Releases (maintainers)
+
+The asset filenames must match `nsrl-modern.bloom`, `nsrl-mobile.bloom`, `nsrl-all.bloom` exactly — these are the filenames `install.go` downloads from `NSRLBloomURL{Modern,Mobile,All}`.
+
+1. Bump `NSRL_VERSION` in `Taskfile.nsrl.yml` and run a fresh build of all three variants:
+   ```sh
+   task nsrl:clean
+   task nsrl:build-modern
+   task nsrl:build-mobile
+   task nsrl:build-all
+   ```
+2. Create the release with tag `nsrl-<NSRL_VERSION>` (e.g. `nsrl-2026.03.1`) and attach the three bloom files:
+   ```sh
+   VERSION=$(grep '^  NSRL_VERSION:' Taskfile.nsrl.yml | awk -F'"' '{print $2}')
+   gh release create "nsrl-${VERSION}" \
+     --title "NSRL ${VERSION}" \
+     --notes "NSRL RDS ${VERSION} bloom filters (FPR 1%)." \
+     db/nsrl-modern.bloom db/nsrl-mobile.bloom db/nsrl-all.bloom
+   ```
+3. Update the three `NSRLBloomURL*` constants in `install.go` to point at the new tag, commit, and open a PR.
+4. Verify a fresh install picks up the new files:
+   ```sh
+   ./ftrove --install /tmp/ft-test --nsrl-variant all
+   ```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You can also build a custom Bloom filter from any newline-delimited list of SHA1
 admftrove --creatensrl hashes.txt --nsrlversion "my-hashset-v1"
 ```
 
-Optional flags: `--nsrl-estimate` (expected hash count; auto-counted from file if omitted) and `--nsrl-fpr` (false positive rate, default `0.01`). Copy the resulting `nsrl.bloom` into `db/`.
+Optional flags: `--nsrl-out` (output filename, default `nsrl.bloom`), `--nsrl-estimate` (expected hash count; auto-counted from file if omitted) and `--nsrl-fpr` (false positive rate, default `0.01`). Copy the resulting bloom file into `db/`. ftrove loads `db/nsrl-<variant>.bloom` based on `--nsrl-variant` (default `all`), with a fallback to `db/nsrl.bloom`.
 
 ## Running a scan
 

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -49,15 +49,17 @@ tasks:
       - test -f {{.DIST_DIR}}/db/siegfried.sig
 
   nsrl:
-    desc: Copy nsrl.bloom into the distribution folder
+    desc: Copy an nsrl bloom filter into the distribution folder (NSRL_VARIANT=modern|mobile|all, default all)
     deps: [setup]
+    vars:
+      NSRL_VARIANT: '{{default "all" .NSRL_VARIANT}}'
     preconditions:
-      - sh: test -f db/nsrl.bloom
-        msg: "db/nsrl.bloom not found. Build it first with: task nsrl:build-all"
+      - sh: test -f db/nsrl-{{.NSRL_VARIANT}}.bloom
+        msg: "db/nsrl-{{.NSRL_VARIANT}}.bloom not found. Build it first with: task nsrl:build-{{.NSRL_VARIANT}}"
     cmds:
-      - cp db/nsrl.bloom {{.DIST_DIR}}/db/nsrl.bloom
+      - cp db/nsrl-{{.NSRL_VARIANT}}.bloom {{.DIST_DIR}}/db/nsrl-{{.NSRL_VARIANT}}.bloom
     status:
-      - test -f {{.DIST_DIR}}/db/nsrl.bloom
+      - test -f {{.DIST_DIR}}/db/nsrl-{{.NSRL_VARIANT}}.bloom
 
   readme:
     desc: Generate a quick-start README for the distribution bundle
@@ -86,7 +88,7 @@ tasks:
 
         The db/ folder contains:
           - siegfried.sig   PRONOM signature database (pre-installed)
-          - nsrl.bloom      NSRL Bloom filter (pre-installed)
+          - nsrl-all.bloom  NSRL Bloom filter (pre-installed, variant: all)
           - filetrove.db    created by --install (per-project scan database)
 
         For full documentation see: https://github.com/steffenfritz/FileTrove

--- a/Taskfile.nsrl.yml
+++ b/Taskfile.nsrl.yml
@@ -8,22 +8,24 @@ vars:
 
 tasks:
   check:
-    desc: Compare local nsrl.bloom version against configured NSRL_VERSION
+    desc: Compare local nsrl bloom filter versions against configured NSRL_VERSION
     silent: true
     cmds:
       - |
-        if [ ! -f db/nsrl.bloom ]; then
-          echo "No local nsrl.bloom found. Run one of the build targets."
+        FOUND=0
+        for VARIANT in modern mobile all; do
+          FILE="db/nsrl-${VARIANT}.bloom"
+          if [ -f "$FILE" ]; then
+            FOUND=1
+            LOCAL=$(./cmd/admftrove/admftrove --nsrl-info "$FILE" 2>/dev/null | grep '^Version:' | awk '{print $2}')
+            printf "%-8s %s\n" "${VARIANT}:" "$LOCAL"
+          fi
+        done
+        if [ "$FOUND" -eq 0 ]; then
+          echo "No local bloom files found. Run one of the build targets."
           exit 0
         fi
-        LOCAL=$(./cmd/admftrove/admftrove --nsrl-info db/nsrl.bloom 2>/dev/null | grep '^Version:' | awk '{print $2}')
-        echo "Local version:      $LOCAL"
         echo "Configured version: {{.NSRL_VERSION}}"
-        if echo "$LOCAL" | grep -q "^{{.NSRL_VERSION}}"; then
-          echo "Up to date."
-        else
-          echo "Update available. Run a build target to rebuild."
-        fi
 
   download-modern:
     desc: Download, verify, and extract NSRL Modern Minimal RDS (SQLite)
@@ -82,9 +84,11 @@ tasks:
       - test -n "$(find {{.NSRL_WORK}}/legacy -name '*.db' -type f 2>/dev/null)"
 
   test:
-    desc: Verify db/nsrl.bloom contains all known NSRL hashes from testdata
+    desc: Verify a bloom file contains all known NSRL hashes from testdata
+    vars:
+      NSRL_BLOOM_FILE: '{{default "db/nsrl.bloom" .NSRL_BLOOM_FILE}}'
     cmds:
-      - go test -v -count=1 -run TestBloomWithRealNSRL .
+      - NSRL_BLOOM_FILE={{.NSRL_BLOOM_FILE}} go test -v -count=1 -run TestBloomWithRealNSRL .
 
   build-modern:
     desc: "Build Bloom filter from Modern RDS only (~150 MB at 1% FPR)."
@@ -92,15 +96,17 @@ tasks:
     cmds:
       - task: download-modern
       - |
+        mkdir -p db
         DB=$(find {{.NSRL_WORK}}/modern -name '*.db' -type f)
         COUNT=$(sqlite3 -readonly "$DB" "SELECT COUNT(*) FROM DISTINCT_HASH;")
         sqlite3 -readonly "$DB" "SELECT sha1 FROM DISTINCT_HASH;" | \
-          ./cmd/admftrove/admftrove --creatensrl - --nsrlversion "{{.NSRL_VERSION}}-modern" --nsrl-fpr {{.NSRL_FPR}} --nsrl-estimate "$COUNT"
-      - mkdir -p db && mv nsrl.bloom db/nsrl.bloom
+          ./cmd/admftrove/admftrove --creatensrl - --nsrlversion "{{.NSRL_VERSION}}-modern" --nsrl-fpr {{.NSRL_FPR}} --nsrl-estimate "$COUNT" --nsrl-out db/nsrl-modern.bloom
       - task: test
+        vars:
+          NSRL_BLOOM_FILE: db/nsrl-modern.bloom
     status:
-      - test -f db/nsrl.bloom
-      - ./cmd/admftrove/admftrove --nsrl-info db/nsrl.bloom 2>/dev/null | grep -q "^Version:.*{{.NSRL_VERSION}}-modern"
+      - test -f db/nsrl-modern.bloom
+      - ./cmd/admftrove/admftrove --nsrl-info db/nsrl-modern.bloom 2>/dev/null | grep -q "^Version:.*{{.NSRL_VERSION}}-modern"
 
   build-mobile:
     desc: "Build Bloom filter from Modern + Android + iOS (~200 MB at 1% FPR)."
@@ -110,6 +116,7 @@ tasks:
       - task: download-android
       - task: download-ios
       - |
+        mkdir -p db
         DB_MODERN=$(find {{.NSRL_WORK}}/modern -name '*.db' -type f)
         DB_ANDROID=$(find {{.NSRL_WORK}}/android -name '*.db' -type f)
         DB_IOS=$(find {{.NSRL_WORK}}/ios -name '*.db' -type f)
@@ -125,13 +132,14 @@ tasks:
             sqlite3 -readonly "$DB_IOS"     "SELECT sha1 FROM DISTINCT_HASH;"; \
           } | ./cmd/admftrove/admftrove --creatensrl - \
               --nsrlversion "{{.NSRL_VERSION}}-mobile" --nsrl-fpr {{.NSRL_FPR}} \
-              --nsrl-estimate "$COUNT"
+              --nsrl-estimate "$COUNT" --nsrl-out db/nsrl-mobile.bloom
         '
-      - mkdir -p db && mv nsrl.bloom db/nsrl.bloom
       - task: test
+        vars:
+          NSRL_BLOOM_FILE: db/nsrl-mobile.bloom
     status:
-      - test -f db/nsrl.bloom
-      - ./cmd/admftrove/admftrove --nsrl-info db/nsrl.bloom 2>/dev/null | grep -q "^Version:.*{{.NSRL_VERSION}}-mobile"
+      - test -f db/nsrl-mobile.bloom
+      - ./cmd/admftrove/admftrove --nsrl-info db/nsrl-mobile.bloom 2>/dev/null | grep -q "^Version:.*{{.NSRL_VERSION}}-mobile"
 
   build-all:
     desc: "Build Bloom filter from all RDS subsets (~240 MB at 1% FPR)."
@@ -142,6 +150,7 @@ tasks:
       - task: download-ios
       - task: download-legacy
       - |
+        mkdir -p db
         DB_MODERN=$(find {{.NSRL_WORK}}/modern -name '*.db' -type f)
         DB_ANDROID=$(find {{.NSRL_WORK}}/android -name '*.db' -type f)
         DB_IOS=$(find {{.NSRL_WORK}}/ios -name '*.db' -type f)
@@ -160,13 +169,14 @@ tasks:
             sqlite3 -readonly "$DB_LEGACY"  "SELECT sha1 FROM DISTINCT_HASH;"; \
           } | ./cmd/admftrove/admftrove --creatensrl - \
               --nsrlversion "{{.NSRL_VERSION}}-all" --nsrl-fpr {{.NSRL_FPR}} \
-              --nsrl-estimate "$COUNT"
+              --nsrl-estimate "$COUNT" --nsrl-out db/nsrl-all.bloom
         '
-      - mkdir -p db && mv nsrl.bloom db/nsrl.bloom
       - task: test
+        vars:
+          NSRL_BLOOM_FILE: db/nsrl-all.bloom
     status:
-      - test -f db/nsrl.bloom
-      - ./cmd/admftrove/admftrove --nsrl-info db/nsrl.bloom 2>/dev/null | grep -q "^Version:.*{{.NSRL_VERSION}}-all"
+      - test -f db/nsrl-all.bloom
+      - ./cmd/admftrove/admftrove --nsrl-info db/nsrl-all.bloom 2>/dev/null | grep -q "^Version:.*{{.NSRL_VERSION}}-all"
 
   clean:
     desc: Remove NSRL build artifacts

--- a/cmd/admftrove/main.go
+++ b/cmd/admftrove/main.go
@@ -25,6 +25,7 @@ func main() {
 	nsrlversion := flag.String("nsrlversion", "", "NSRL version string used for session information.")
 	nsrlEstimate := flag.Uint("nsrl-estimate", 0, "Estimated number of hashes for Bloom filter sizing. 0 = auto-count from input file.")
 	nsrlFPR := flag.Float64("nsrl-fpr", 0.0001, "Target false positive rate for the Bloom filter (default: 0.01%).")
+	nsrlOut := flag.String("nsrl-out", "nsrl.bloom", "Output filename for the created Bloom filter file.")
 	updateDB := flag.String("updatedb", "", "Update a filetrove sqlite database to the next version. Expects the directory of the database file.")
 	version := flag.Bool("version", false, "Show version")
 
@@ -48,7 +49,7 @@ func main() {
 	}
 
 	if len(*createNSRL) != 0 {
-		err := ft.CreateNSRLBloom(*createNSRL, *nsrlversion, "nsrl.bloom", *nsrlEstimate, *nsrlFPR)
+		err := ft.CreateNSRLBloom(*createNSRL, *nsrlversion, *nsrlOut, *nsrlEstimate, *nsrlFPR)
 		if err != nil {
 			logger.Error("Could not create Bloom filter from NSRL text file", slog.String("error", err.Error()))
 		}

--- a/cmd/ftrove/main.go
+++ b/cmd/ftrove/main.go
@@ -305,7 +305,11 @@ func main() {
 
 	// Load NSRL Bloom filter into memory (optional — scanning continues without it)
 	var nsrlFilter *ft.NSRLFilter
-	nsrlFilter, err = ft.LoadNSRL(filepath.Join("db", "nsrl.bloom"))
+	bloomPath := filepath.Join("db", "nsrl-"+*nsrlVariant+".bloom")
+	if _, statErr := os.Stat(bloomPath); os.IsNotExist(statErr) {
+		bloomPath = filepath.Join("db", "nsrl.bloom")
+	}
+	nsrlFilter, err = ft.LoadNSRL(bloomPath)
 	if err != nil {
 		logger.Warn("NSRL bloom filter not available, NSRL checks disabled", slog.String("reason", err.Error()))
 		nsrlFilter = nil

--- a/install.go
+++ b/install.go
@@ -66,7 +66,7 @@ func InstallFT(installPath string, version string, initdate string, nsrlVariant 
 	}
 
 	// Try to find, copy, or download the NSRL bloom filter
-	nsrlDst := filepath.Join(installPath, "db", "nsrl.bloom")
+	nsrlDst := filepath.Join(installPath, "db", "nsrl-"+nsrlVariant+".bloom")
 	if _, err := os.Stat(nsrlDst); os.IsNotExist(err) {
 		if err := copyNSRLBloom(nsrlDst); err == nil {
 			fmt.Println("Copied NSRL bloom filter to " + nsrlDst)
@@ -75,7 +75,7 @@ func InstallFT(installPath string, version string, initdate string, nsrlVariant 
 			if dlErr := DownloadNSRLBloom(nsrlDst, nsrlURL); dlErr != nil {
 				fmt.Println("\nNSRL bloom filter could not be downloaded: " + dlErr.Error())
 				fmt.Println("Build it manually with: task nsrl:build-" + nsrlVariant)
-				fmt.Println("Or copy an existing nsrl.bloom file into the db/ directory.")
+				fmt.Printf("Or copy an existing nsrl-%s.bloom file into the db/ directory.\n", nsrlVariant)
 				fmt.Println("Scanning will work without it; NSRL checks will be skipped.")
 			} else {
 				fmt.Println("Downloaded NSRL bloom filter to " + nsrlDst)
@@ -110,22 +110,23 @@ func DownloadNSRLBloom(dst string, url string) error {
 	return err
 }
 
-// copyNSRLBloom tries to find and copy nsrl.bloom from known locations
+// copyNSRLBloom tries to find and copy the bloom filter from known locations
 // into the destination path. It looks next to the binary and in db/.
 func copyNSRLBloom(dst string) error {
+	bloomName := filepath.Base(dst)
 	candidates := []string{
 		// Relative to CWD (repo root or dist bundle)
-		filepath.Join("db", "nsrl.bloom"),
+		filepath.Join("db", bloomName),
 		// Two levels up from cmd/ftrove/ to repo root
-		filepath.Join("..", "..", "db", "nsrl.bloom"),
+		filepath.Join("..", "..", "db", bloomName),
 	}
 	// Also check next to the running binary
 	if exe, err := os.Executable(); err == nil {
 		exeDir := filepath.Dir(exe)
 		candidates = append(candidates,
-			filepath.Join(exeDir, "db", "nsrl.bloom"),
+			filepath.Join(exeDir, "db", bloomName),
 			// Binary in cmd/ftrove/, bloom in repo root db/
-			filepath.Join(exeDir, "..", "..", "db", "nsrl.bloom"),
+			filepath.Join(exeDir, "..", "..", "db", bloomName),
 		)
 	}
 
@@ -139,7 +140,7 @@ func copyNSRLBloom(dst string) error {
 			return copyFile(src, dst)
 		}
 	}
-	return fmt.Errorf("nsrl.bloom not found in any known location")
+	return fmt.Errorf("%s not found in any known location", bloomName)
 }
 
 func copyFile(src, dst string) error {
@@ -169,17 +170,20 @@ func CheckInstall(version string) error {
 	if os.IsNotExist(err) {
 		fmt.Println("ERROR: filetrove database does not exist.")
 	}
-	_, dberr := os.Stat(filepath.Join("db", "nsrl.bloom"))
-	if os.IsNotExist(dberr) {
-		// Check for legacy nsrl.db and provide migration hint
+	bloomMatches, _ := filepath.Glob(filepath.Join("db", "nsrl-*.bloom"))
+	// Also accept legacy nsrl.bloom for backward compatibility
+	if _, legacyBloom := os.Stat(filepath.Join("db", "nsrl.bloom")); legacyBloom == nil {
+		bloomMatches = append(bloomMatches, filepath.Join("db", "nsrl.bloom"))
+	}
+	if len(bloomMatches) == 0 {
 		if _, legacyErr := os.Stat(filepath.Join("db", "nsrl.db")); legacyErr == nil {
-			fmt.Println("ERROR: Legacy nsrl.db detected. Run 'task nsrl:build-all' or rebuild with admftrove --creatensrl to create nsrl.bloom.")
+			fmt.Println("ERROR: Legacy nsrl.db detected. Run 'task nsrl:build-all' or rebuild with admftrove --creatensrl to create an nsrl-<variant>.bloom file.")
 		} else {
 			fmt.Println("ERROR: nsrl bloom filter does not exist.")
 		}
 	}
 
-	if dberr == nil {
+	if len(bloomMatches) > 0 {
 		ftdb, connerr := ConnectFileTroveDB("db")
 		if connerr != nil {
 			fmt.Println("Could not connect or open database. Error: " + connerr.Error())

--- a/nsrl_test.go
+++ b/nsrl_test.go
@@ -180,9 +180,12 @@ func TestBloomEmptyFile(t *testing.T) {
 }
 
 func TestBloomWithRealNSRL(t *testing.T) {
-	bloomFile := "db/nsrl.bloom"
+	bloomFile := os.Getenv("NSRL_BLOOM_FILE")
+	if bloomFile == "" {
+		bloomFile = "db/nsrl.bloom"
+	}
 	if _, err := os.Stat(bloomFile); os.IsNotExist(err) {
-		t.Skip("db/nsrl.bloom not present; run 'task nsrl:build-all' first")
+		t.Skipf("%s not present; run 'task nsrl:build-modern/mobile/all' or set NSRL_BLOOM_FILE", bloomFile)
 	}
 
 	nf, err := LoadNSRL(bloomFile)


### PR DESCRIPTION
## Summary

- Each NSRL build target writes to its own file (`db/nsrl-modern.bloom`, `db/nsrl-mobile.bloom`, `db/nsrl-all.bloom`) so all three variants can coexist. Previously every variant overwrote `db/nsrl.bloom`, making sequential builds clobber each other.
- `ftrove --nsrl-variant` now selects which bloom file to load at scan time, falling back to `db/nsrl.bloom` for existing installs.
- New `admftrove --nsrl-out` flag lets the build write directly to a chosen path; the `mv nsrl.bloom db/nsrl.bloom` step in each task is gone.

## Changes

- `cmd/admftrove/main.go` — new `--nsrl-out` flag (default `nsrl.bloom` for back-compat)
- `cmd/ftrove/main.go` — `--nsrl-variant` selects `db/nsrl-<variant>.bloom`, with legacy fallback
- `install.go` — saves to `db/nsrl-<variant>.bloom`; `copyNSRLBloom` derives the filename from `dst`; `CheckInstall` accepts any `nsrl-*.bloom` (plus legacy)
- `Taskfile.nsrl.yml` — build tasks pass `--nsrl-out`, drop the `mv` step; `test` task parameterized via `NSRL_BLOOM_FILE`; `check` loops over variants
- `Taskfile.dist.yml` — `dist:nsrl` accepts `NSRL_VARIANT` (default `all`)
- `nsrl_test.go` — `TestBloomWithRealNSRL` reads `NSRL_BLOOM_FILE` env var
- `BUILDING.md` / `README.md` — variant filename references; new maintainer section for publishing bloom files to GitHub Releases via `gh release create`

URL constants in `install.go` already used variant-specific filenames, so no URL changes were needed — the rename only happened on save.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — pre-existing `TestCreateFileList` failure confirmed on `main` (unrelated)
- [x] `admftrove --creatensrl - --nsrl-out /tmp/x.bloom` writes to the path; `--nsrl-info` reads it back
- [x] `NSRL_BLOOM_FILE=/tmp/x.bloom go test -run TestBloomWithRealNSRL .` honors the env var
- [x] Without env var, `TestBloomWithRealNSRL` skips gracefully
- [x] `task --list-all` parses all Taskfile changes
- [ ] End-to-end: build all three variants and confirm `db/nsrl-{modern,mobile,all}.bloom` coexist
- [ ] `ftrove --nsrl-variant modern --indir testdata` loads `db/nsrl-modern.bloom`