### PR TITLE
test: create filewalk fixtures in TestMain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ cmd/ftrove/db
 # Databases
 nsrl_sha1_uniq_*
 nsrl.db
+db/
 
 # NSRL build artifacts
 tmp/nsrl/

--- a/setup_unix_test.go
+++ b/setup_unix_test.go
@@ -1,0 +1,46 @@
+//go:build unix
+
+package filetrove
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"testing"
+)
+
+// TestMain creates fixtures that can't be tracked in git: a file with no read
+// permission and a named pipe. Both are needed by TestCreateFileList to verify
+// that CreateFileList records unreadable files and special files in the
+// skipped list.
+func TestMain(m *testing.M) {
+	const (
+		noaccess = "testdata/noaccess.rtf"
+		pipe     = "testdata/testpipe"
+	)
+
+	if err := os.WriteFile(noaccess, []byte{}, 0o000); err != nil {
+		fmt.Fprintf(os.Stderr, "test setup: create %s: %v\n", noaccess, err)
+		os.Exit(1)
+	}
+	// WriteFile may not honor 0o000 on some umasks; force it.
+	if err := os.Chmod(noaccess, 0o000); err != nil {
+		fmt.Fprintf(os.Stderr, "test setup: chmod %s: %v\n", noaccess, err)
+		os.Exit(1)
+	}
+
+	_ = os.Remove(pipe)
+	if err := syscall.Mkfifo(pipe, 0o600); err != nil {
+		fmt.Fprintf(os.Stderr, "test setup: mkfifo %s: %v\n", pipe, err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	// Restore mode before removing so the file is actually deletable.
+	_ = os.Chmod(noaccess, 0o600)
+	_ = os.Remove(noaccess)
+	_ = os.Remove(pipe)
+
+	os.Exit(code)
+}


### PR DESCRIPTION
## Summary
- Add `TestMain` (Unix-only) that creates `testdata/noaccess.rtf` (mode 0000) and `testdata/testpipe` (named pipe via `syscall.Mkfifo`) before running tests, and cleans them up after — restoring permissions on the unreadable file first so it can be deleted.
- Without this, `TestCreateFileList` fails on a fresh checkout because the test (added in 26f07f6) asserts these two paths land in `wantSkipped`, but they're special files that can't be tracked in git.
- Also add `db/` to `.gitignore` — the local install directory shouldn't be tracked.

## Test plan
- [x] `go test ./...` passes (36 tests)
- [x] Fixtures are removed after the run (no leftover `testdata/noaccess.rtf` or `testdata/testpipe`)
- [ ] CI passes